### PR TITLE
Development for v1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= b0rd2dEAth
-APP_VERSION	:= 1.3.0
+APP_VERSION	:= 1.3.1
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/examples/Easy Installer/package.ini
+++ b/examples/Easy Installer/package.ini
@@ -1,4 +1,4 @@
-;version=0.3.1
+;version=0.3.2
 ;creator=b0rd2dEAth
 ;about='This package contains commands to update/install a variety of overlays and packages.'
 
@@ -7,28 +7,28 @@ json_file_source '/switch/.packages/Easy Installer/overlays.json' name
 
 delete /config/ultrahand/downloads/zip-url.json
 download {json_file_source(*,zip-url)} /config/ultrahand/downloads/zip-url.json
-json_data /config/ultrahand/downloads/zip-url.json
-download {json_data(0,assets,{json_file_source(*,download-entry)},browser_download_url)} /config/ultrahand/downloads/{json_data(0,assets,{json_file_source(*,download-entry)},name)}
-unzip /config/ultrahand/downloads/{json_data(0,assets,{json_file_source(*,download-entry)},name)} /config/ultrahand/downloads/zip-url/
+json_file /config/ultrahand/downloads/zip-url.json
+download {json_file(0,assets,{json_file_source(*,download-entry)},browser_download_url)} /config/ultrahand/downloads/{json_file(0,assets,{json_file_source(*,download-entry)},name)}
+unzip /config/ultrahand/downloads/{json_file(0,assets,{json_file_source(*,download-entry)},name)} /config/ultrahand/downloads/zip-url/
 move /config/ultrahand/downloads/zip-url/ /
-delete /config/ultrahand/downloads/{json_data(0,assets,{json_file_source(*,download-entry)},name)}
+delete /config/ultrahand/downloads/{json_file(0,assets,{json_file_source(*,download-entry)},name)}
 delete /config/ultrahand/downloads/zip-url.json
 
 delete /config/ultrahand/downloads/zip-url-version.json
 download {json_file_source(*,zip-url-version)} /config/ultrahand/downloads/zip-url-version.json
-json_data /config/ultrahand/downloads/zip-url-version.json
-download {json_data(assets,{json_file_source(*,download-entry)},browser_download_url)} /config/ultrahand/downloads/{json_data(assets,{json_file_source(*,download-entry)},name)}
-unzip /config/ultrahand/downloads/{json_data(assets,{json_file_source(*,download-entry)},name)} /config/ultrahand/downloads/zip-url-version/
+json_file /config/ultrahand/downloads/zip-url-version.json
+download {json_file(assets,{json_file_source(*,download-entry)},browser_download_url)} /config/ultrahand/downloads/{json_file(assets,{json_file_source(*,download-entry)},name)}
+unzip /config/ultrahand/downloads/{json_file(assets,{json_file_source(*,download-entry)},name)} /config/ultrahand/downloads/zip-url-version/
 move /config/ultrahand/downloads/zip-url-version/ /
-delete /config/ultrahand/downloads/{json_data(assets,{json_file_source(*,download-entry)},name)}
+delete /config/ultrahand/downloads/{json_file(assets,{json_file_source(*,download-entry)},name)}
 delete /config/ultrahand/downloads/zip-url-version.json
 
 ; for if file is .ovl
 delete /config/ultrahand/downloads/ovl-url.json
 download {json_file_source(*,ovl-url)} /config/ultrahand/downloads/ovl-url.json
-json_data /config/ultrahand/downloads/ovl-url.json
-download {json_data(0,assets,{json_file_source(*,download-entry)},browser_download_url)}  /config/ultrahand/downloads/{json_data(0,assets,{json_file_source(*,download-entry)},name)}
-move /config/ultrahand/downloads/{json_data(0,assets,{json_file_source(*,download-entry)},name)} /switch/.overlays/
+json_file /config/ultrahand/downloads/ovl-url.json
+download {json_file(0,assets,{json_file_source(*,download-entry)},browser_download_url)}  /config/ultrahand/downloads/{json_file(0,assets,{json_file_source(*,download-entry)},name)}
+move /config/ultrahand/downloads/{json_file(0,assets,{json_file_source(*,download-entry)},name)} /switch/.overlays/
 delete /config/ultrahand/downloads/ovl-url.json
 
 [*Install Package]

--- a/source/get_funcs.hpp
+++ b/source/get_funcs.hpp
@@ -450,7 +450,7 @@ std::string replaceJsonSourcePlaceholder(const std::string& placeholder, const s
     
 
     std::string replacement = placeholder;
-    std::string searchString = "{json_data(";
+    std::string searchString = "{json_file(";
     if (type == "file") {
         searchString = "{json_file_source(";
         root = json_load_file(jsonSource.c_str(), 0, &error);
@@ -565,7 +565,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
             } 
             if ((usingJsonSource) && (cmd[0] == "json_source")) {
                 jsonSource = removeQuotes(cmd[1]);
-            } 
+            }
         }
         if (!toggle or addCommands) {
             std::vector<std::string> modifiedCmd = cmd;
@@ -582,6 +582,8 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                     arg = replacePlaceholder(arg, "{file_name}", getNameFromPath(entry));
                 } else if (arg.find("{folder_name}") != std::string::npos) {
                     arg = replacePlaceholder(arg, "{folder_name}", getParentDirNameFromPath(entry));
+                } else if (arg.find("{json_file(") != std::string::npos) {
+                    arg = replaceJsonSourcePlaceholder(arg, jsonSource);
                 } else if (usingJsonSource && (arg.find("{json_source(") != std::string::npos)) {
                     std::string countStr = entry;
                     
@@ -591,7 +593,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                     //logMessage(std::string("post arg: ") + arg);
 
                     
-                    size_t startPos = arg.find("{json_file_source(");
+                    size_t startPos = arg.find("{json_source(");
                     size_t endPos = arg.find(")}");
                     if (endPos != std::string::npos && endPos > startPos) {
                         replacement = replaceJsonSourcePlaceholder(arg.substr(startPos, endPos - startPos + 2), jsonSource, "variable");

--- a/source/get_funcs.hpp
+++ b/source/get_funcs.hpp
@@ -560,6 +560,9 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                     }
                 }
             }
+            if (cmd[0] == "json_file") {
+                jsonSource = preprocessPath(cmd[1]);
+            } 
             if ((usingJsonSource) && (cmd[0] == "json_file_source")) {
                 jsonSource = preprocessPath(cmd[1]);
             } 

--- a/source/get_funcs.hpp
+++ b/source/get_funcs.hpp
@@ -521,7 +521,10 @@ std::string replaceJsonPlaceholder(const std::string& arg, const std::string& co
  */
 std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::vector<std::string>>& commands, const std::string& entry, bool toggle = false, bool on = true) {
     std::vector<std::vector<std::string>> modifiedCommands;
-    std::string jsonPath, jsonSourcePath, jsonString, replacement;
+    std::string listString, jsonPath, jsonSourcePath, jsonString, replacement;
+    std::vector<std::string> listData;
+    int listIndex;
+    
     json_t* jsonDict = nullptr;
     json_error_t error;
     
@@ -542,6 +545,11 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                 }
             }
             
+            if ((cmd[0] == "list") || (cmd[0] == "list_source")) {
+                listString = removeQuotes(cmd[1]);
+                listData = stringToList(listString);
+            }
+            
             if ((cmd[0] == "json_file_source") || (cmd[0] == "json_file")) {
                 jsonPath = preprocessPath(cmd[1]);
                 
@@ -553,7 +561,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
             } else if ((cmd[0] == "json_source") || (cmd[0] == "json")) {
                 jsonString = removeQuotes(cmd[1]);
                 
-                jsonDict = stringToJson(removeQuotes(jsonString.c_str()));
+                jsonDict = stringToJson(jsonString.c_str());
                 if (!jsonDict) {
                     //jsonDict = nullptr;
                     return modifiedCommands;
@@ -563,9 +571,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
         if (!toggle or addCommands) {
             std::vector<std::string> modifiedCmd = cmd;
             for (auto& arg : modifiedCmd) {
-                if (!toggle && (arg.find("{list_source}") != std::string::npos)) {
-                    arg = replacePlaceholder(arg, "{list_source}", entry);
-                } else if (!toggle && (arg.find("{file_source}") != std::string::npos)) {
+                if (!toggle && (arg.find("{file_source}") != std::string::npos)) {
                     arg = replacePlaceholder(arg, "{file_source}", entry);
                 } else if (on && (arg.find("{file_source_on}") != std::string::npos)) {
                     arg = replacePlaceholder(arg, "{file_source_on}", entry);
@@ -575,9 +581,27 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                     arg = replacePlaceholder(arg, "{file_name}", getNameFromPath(entry));
                 } else if (arg.find("{folder_name}") != std::string::npos) {
                     arg = replacePlaceholder(arg, "{folder_name}", getParentDirNameFromPath(entry));
-                } else if (arg.find("{json(") != std::string::npos) {
-                    std::string countStr = entry;
+                } else if (!toggle && (arg.find("{list(") != std::string::npos)) {
+                    size_t startPos = arg.find("{list(");
+                    size_t endPos = arg.find(")}");
+                    if (endPos != std::string::npos && endPos > startPos) {
+                        listIndex = stringToNumber(arg.substr(startPos, endPos - startPos + 2));
+                        replacement = listData[listIndex];
+                        arg.replace(startPos, endPos - startPos + 2, replacement);
+                    }
+                } else if (!toggle && (arg.find("{list_source(") != std::string::npos)) {
+                    //arg = replacePlaceholder(arg, "{list_source}", entry);
                     arg = replacePlaceholder(arg, "*", entry);
+                    size_t startPos = arg.find("{list_source(");
+                    size_t endPos = arg.find(")}");
+                    if (endPos != std::string::npos && endPos > startPos) {
+                        listIndex = stringToNumber(arg.substr(startPos, endPos - startPos + 2));
+                        replacement = listData[listIndex];
+                        arg.replace(startPos, endPos - startPos + 2, replacement);
+                    }
+                } else if (arg.find("{json(") != std::string::npos) {
+                    //std::string countStr = entry;
+                    //arg = replacePlaceholder(arg, "*", entry);
                     size_t startPos = arg.find("{json(");
                     size_t endPos = arg.find(")}");
                     if (endPos != std::string::npos && endPos > startPos) {
@@ -585,7 +609,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                         arg.replace(startPos, endPos - startPos + 2, replacement);
                     }
                 } else if (arg.find("{json_file(") != std::string::npos) {
-                    std::string countStr = entry;
+                    //std::string countStr = entry;
                     arg = replacePlaceholder(arg, "*", entry);
                     size_t startPos = arg.find("{json_file(");
                     size_t endPos = arg.find(")}");
@@ -594,7 +618,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                         arg.replace(startPos, endPos - startPos + 2, replacement);
                     }
                 } else if (arg.find("{json_source(") != std::string::npos) {
-                    std::string countStr = entry;
+                    //std::string countStr = entry;
                     arg = replacePlaceholder(arg, "*", entry);
                     size_t startPos = arg.find("{json_source(");
                     size_t endPos = arg.find(")}");
@@ -603,7 +627,7 @@ std::vector<std::vector<std::string>> getModifyCommands(const std::vector<std::v
                         arg.replace(startPos, endPos - startPos + 2, replacement);
                     }
                 } else if (arg.find("{json_file_source(") != std::string::npos) {
-                    std::string countStr = entry;
+                    //std::string countStr = entry;
                     arg = replacePlaceholder(arg, "*", entry);
                     size_t startPos = arg.find("{json_file_source(");
                     size_t endPos = arg.find(")}");

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -593,7 +593,7 @@ public:
                         pathReplaceOff = cmd[1];
                         useToggle = true;
                     }
-                    //else if (cmd[0] == "json_data") {
+                    //else if (cmd[0] == "json_file") {
                     //    jsonPath = cmd[1];
                     //}
                 } 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -410,7 +410,7 @@ public:
                         if (keys & KEY_A) {
                             // Replace "{json_file_source}" with entry in commands, then execute
                             std::string countString = std::to_string(count);
-                            std::vector<std::vector<std::string>> modifiedCommands = getModifyCommands(commands, countString, false, true, true);
+                            std::vector<std::vector<std::string>> modifiedCommands = getModifyCommands(commands, countString, false, true);
                             interpretAndExecuteCommand(modifiedCommands);
                             listItem->setValue("DONE");
                             return true;

--- a/source/string_funcs.hpp
+++ b/source/string_funcs.hpp
@@ -209,6 +209,27 @@ bool isFileOrDirectory(const std::string& path) {
 
 
 /**
+ * @brief Converts a string to an integer.
+ *
+ * This function attempts to convert the specified string to an integer.
+ * If the conversion fails due to invalid input or out-of-range values,
+ * it returns 0.
+ *
+ * @param input_string The string to convert to an integer.
+ * @return The converted integer value or 0 on conversion failure.
+ */
+int stringToNumber(const std::string& input_string) {
+    try {
+        return std::stoi(input_string);
+    } catch (const std::invalid_argument& e) {
+        return 0;
+    } catch (const std::out_of_range& e) {
+        return 0;
+    }
+}
+
+
+/**
  * @brief Splits a string into a vector of strings using a delimiter.
  *
  * This function splits the input string into multiple strings using the specified delimiter.

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -319,48 +319,48 @@ bool isDangerousCombination(const std::string& patternPath) {
 void interpretAndExecuteCommand(const std::vector<std::vector<std::string>>& commands) {
     std::string commandName, jsonPath, sourcePath, destinationPath, desiredSection, desiredKey, desiredNewKey, desiredValue, offset, customPattern, hexDataToReplace, hexDataReplacement, fileUrl, occurrence;
     
-    for (auto& unmodifiedCommand : commands) {
+    for (auto& command : commands) {
         
         // Check the command and perform the appropriate action
-        if (unmodifiedCommand.empty()) {
+        if (command.empty()) {
             // Empty command, do nothing
             continue;
         }
 
         // Get the command name (first part of the command)
-        commandName = unmodifiedCommand[0];
+        commandName = command[0];
         //logMessage(commandName);
         //logMessage(command[1]);
         
         
-        std::vector<std::string> command;
+        //std::vector<std::string> command;
         
-        // Modify the command to replace {json_data} placeholder if jsonPath is available
-        if (!jsonPath.empty()) {
-            std::vector<std::string> modifiedCommand;
-            for (const std::string& commandArg : unmodifiedCommand) {
-                if (commandArg.find("{json_data(") != std::string::npos) {
-                    // Create a copy of the string and modify it
-                    std::string modifiedArg = commandArg;
-                    modifiedArg = replaceJsonSourcePlaceholder(modifiedArg, jsonPath);
-                    // Use modifiedArg as needed
-                    modifiedCommand.push_back(modifiedArg);
-                } else {
-                    modifiedCommand.push_back(commandArg);
-                }
-            }
-            command = modifiedCommand;
-        } else {
-            command = unmodifiedCommand;
-        }
+        // Modify the command to replace {json_file} placeholder if jsonPath is available
+        //if (!jsonPath.empty()) {
+        //    std::vector<std::string> modifiedCommand;
+        //    for (const std::string& commandArg : unmodifiedCommand) {
+        //        if (commandArg.find("{json_file(") != std::string::npos) {
+        //            // Create a copy of the string and modify it
+        //            std::string modifiedArg = commandArg;
+        //            modifiedArg = replaceJsonSourcePlaceholder(modifiedArg, jsonPath);
+        //            // Use modifiedArg as needed
+        //            modifiedCommand.push_back(modifiedArg);
+        //        } else {
+        //            modifiedCommand.push_back(commandArg);
+        //        }
+        //    }
+        //    command = modifiedCommand;
+        //} else {
+        //    command = unmodifiedCommand;
+        //}
         
         
         
-        if (commandName == "json_data") {
-            if (command.size() >= 2) {
-                jsonPath = preprocessPath(command[1]);
-            }
-        } else if (commandName == "make" || commandName == "mkdir") {
+        //if (commandName == "json_file") {
+        //    if (command.size() >= 2) {
+        //        jsonPath = preprocessPath(command[1]);
+        //    }
+        if (commandName == "make" || commandName == "mkdir") {
             // Delete command
             if (command.size() >= 2) {
                 sourcePath = preprocessPath(command[1]);


### PR DESCRIPTION
Here are the list of changes:

1. `json_data` (the non source version) is now `json_file`
2. `json` is now a new non-source version of `json_source` for storing data within the `package.ini`
3. `list_source` has been fixed.  Items defined in list can be called by `{list_source(<INDEX>)}`
4. `list` is now a new non-source version of `list_source`.  Items defined in list can be called by `{list(<INDEX>)}`

**WARNING: Any package previously using `json_data` function will now require a rename to `json_file`.**

Affected example `Easy Installer` has been updated for v1.3.1.

Fixed a number of back-end issues for json and list data parsing.  
This is a continuation of the advanced functions renaming that I've started with v1.3.0 to simplify the naming of all these new command types.