### PR TITLE
Development for v1.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= b0rd2dEAth
-APP_VERSION	:= 1.3.2
+APP_VERSION	:= 1.3.3
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/source/get_funcs.hpp
+++ b/source/get_funcs.hpp
@@ -587,10 +587,10 @@ std::vector<std::vector<std::string>> getSourceReplacement(const std::vector<std
             }
         }
         //logMessage("After source replacement: " + arg);
-        line = "";
-        for (auto& cmd : modifiedCmd) {
-            line = line +" "+cmd;
-        }
+        //line = "";
+        //for (auto& cmd : modifiedCmd) {
+        //    line = line +" "+cmd;
+        //}
         //logMessage("source modifiedCmd post:"+line);
         modifiedCommands.emplace_back(modifiedCmd);
     }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -318,7 +318,8 @@ bool isDangerousCombination(const std::string& patternPath) {
  * @param commands A list of commands, where each command is represented as a vector of strings.
  */
 void interpretAndExecuteCommand(const std::vector<std::vector<std::string>> commands) {
-    std::string commandName, sourcePath, destinationPath, desiredSection, desiredKey, desiredNewKey, desiredValue, offset, customPattern, hexDataToReplace, hexDataReplacement, fileUrl, occurrence;
+    std::string commandName, sourcePath, destinationPath, desiredSection, desiredNewSection, desiredKey, desiredNewKey, desiredValue, \
+        offset, customPattern, hexDataToReplace, hexDataReplacement, fileUrl, occurrence;
     
     bool logging = true;
     
@@ -492,7 +493,23 @@ void interpretAndExecuteCommand(const std::vector<std::vector<std::string>> comm
                 //logMessage( "Invalid move command.");
                 //std::cout << "Invalid move command. Usage: move <source_path> <destination_path>" << std::endl;
             }
-
+        } else if (commandName == "add-ini-section") {
+            // Edit command
+            if (command.size() >= 2) {
+                sourcePath = preprocessPath(command[1]);
+                desiredSection = removeQuotes(command[2]);
+                
+                addIniSection(sourcePath.c_str(), desiredSection.c_str());
+            }
+        } else if (commandName == "rename-ini-section") {
+            // Edit command
+            if (command.size() >= 3) {
+                sourcePath = preprocessPath(command[1]);
+                desiredSection = removeQuotes(command[2]);
+                desiredNewSection = removeQuotes(command[3]);
+                
+                renameIniSection(sourcePath.c_str(), desiredSection.c_str(), desiredNewSection.c_str());
+            }
         } else if (commandName == "set-ini-val" || commandName == "set-ini-value") {
             // Edit command
             if (command.size() >= 5) {


### PR DESCRIPTION
1. Fixed dropdown toggles. Setup double click prevention to ensure commands are properly parsed.
2. New auto-generated `config.ini` for each `package.ini` within the package folder.
    - `mode`: this can be set to `default`, `option`, or `toggle`
    - `grouping`: this can be set to `default` or `split` (split splits commands into groups based upon subfolders)
    - `footer`: `null` by default.  When used with `option` mode, it can be dynamically read on the subMenu.
3. `DONE` is now replaced by a checkmark.

