### PR TITLE
Development for v1.3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= b0rd2dEAth
-APP_VERSION	:= 1.3.3
+APP_VERSION	:= 1.3.4
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -14,6 +14,9 @@
  * 
  *   For the latest updates and contributions, visit the project's GitHub repository.
  *   (GitHub Repository: https://github.com/ppkantorski/Ultrahand-Overlay)
+ *
+ *  Copyright (c) 2023 ppkantorski
+ *  All rights reserved.
  ********************************************************************************/
 
 /**

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -14,9 +14,6 @@
  * 
  *   For the latest updates and contributions, visit the project's GitHub repository.
  *   (GitHub Repository: https://github.com/ppkantorski/Ultrahand-Overlay)
- *
- *  Copyright (c) 2023 ppkantorski
- *  All rights reserved.
  ********************************************************************************/
 
 /**
@@ -66,6 +63,13 @@
 #include "../../../source/get_funcs.hpp"
 #include "../../../source/string_funcs.hpp"
 #include "../../../source/ini_funcs.hpp"
+
+// Pre-defined symbols
+static std::string OPTION_SYMBOL = "\u22EF";
+static std::string DROPDOWN_SYMBOL = "\u25B6";
+static std::string CHECKMARK_SYMBOL = "\uE14B";
+static std::string STAR_SYMBOL = "\u2605";
+
 
 // CUSTOM SECTION END
 
@@ -2326,7 +2330,7 @@ namespace tsl {
                 }
 
                 // CUSTOM SECTION START (modification for submenu footer color)
-                if (this->m_value == "\u25B6") {
+                if (this->m_value == DROPDOWN_SYMBOL || this->m_value == OPTION_SYMBOL) {
                     renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45, this->getY() + 45, 20, this->m_faint ? a(tsl::style::color::ColorDescription) : a(tsl::Color(0xFF, 0xFF, 0xFF, 0xFF)));
                 } else {
                     renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45, this->getY() + 45, 20, this->m_faint ? a(tsl::style::color::ColorDescription) : a(tsl::style::color::ColorHighlight));

--- a/source/ini_funcs.hpp
+++ b/source/ini_funcs.hpp
@@ -54,14 +54,14 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
         packageHeader.about = "";
         return packageHeader;
     }
-
+    
     constexpr size_t BufferSize = 131072; // Choose a larger buffer size for reading lines
     char line[BufferSize];
-
+    
     const std::string versionPrefix = ";version=";
     const std::string creatorPrefix = ";creator=";
     const std::string aboutPrefix = ";about=";
-
+    
     while (fgets(line, sizeof(line), file)) {
         std::string strLine(line);
         size_t versionPos = strLine.find(versionPrefix);
@@ -69,7 +69,7 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
             versionPos += versionPrefix.length();
             size_t startPos = strLine.find("'", versionPos);
             size_t endPos = strLine.find("'", startPos + 1);
-
+            
             if (startPos != std::string::npos && endPos != std::string::npos) {
                 // Value enclosed in single quotes
                 packageHeader.version = strLine.substr(startPos + 1, endPos - startPos - 1);
@@ -77,17 +77,17 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
                 // Value not enclosed in quotes
                 packageHeader.version = strLine.substr(versionPos, endPos - versionPos);
             }
-
+            
             // Remove trailing whitespace or newline characters
             packageHeader.version.erase(packageHeader.version.find_last_not_of(" \t\r\n") + 1);
         }
-
+        
         size_t creatorPos = strLine.find(creatorPrefix);
         if (creatorPos != std::string::npos) {
             creatorPos += creatorPrefix.length();
             size_t startPos = strLine.find("'", creatorPos);
             size_t endPos = strLine.find("'", startPos + 1);
-
+            
             if (startPos != std::string::npos && endPos != std::string::npos) {
                 // Value enclosed in single quotes
                 packageHeader.creator = strLine.substr(startPos + 1, endPos - startPos - 1);
@@ -95,17 +95,17 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
                 // Value not enclosed in quotes
                 packageHeader.creator = strLine.substr(creatorPos, endPos - creatorPos);
             }
-
+            
             // Remove trailing whitespace or newline characters
             packageHeader.creator.erase(packageHeader.creator.find_last_not_of(" \t\r\n") + 1);
         }
-
+        
         size_t aboutPos = strLine.find(aboutPrefix);
         if (aboutPos != std::string::npos) {
             aboutPos += aboutPrefix.length();
             size_t startPos = strLine.find("'", aboutPos);
             size_t endPos = strLine.find("'", startPos + 1);
-
+            
             if (startPos != std::string::npos && endPos != std::string::npos) {
                 // Value enclosed in single quotes
                 packageHeader.about = strLine.substr(startPos + 1, endPos - startPos - 1);
@@ -113,18 +113,18 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
                 // Value not enclosed in quotes
                 packageHeader.about = strLine.substr(aboutPos, endPos - aboutPos);
             }
-
+            
             // Remove trailing whitespace or newline characters
             packageHeader.about.erase(packageHeader.about.find_last_not_of(" \t\r\n") + 1);
         }
-
+        
         if (!packageHeader.version.empty() && !packageHeader.creator.empty() && !packageHeader.about.empty()) {
             break; // Both version and creator found, exit the loop
         }
     }
-
-
-
+    
+    
+    
     fclose(file);
     
     return packageHeader;
@@ -141,7 +141,7 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
  */
 static std::vector<std::string> split(const std::string& str, char delim = ' ') {
     std::vector<std::string> out;
-
+    
     std::size_t current, previous = 0;
     current = str.find(delim);
     while (current != std::string::npos) {
@@ -150,7 +150,7 @@ static std::vector<std::string> split(const std::string& str, char delim = ' ') 
         current = str.find(delim, previous);
     }
     out.push_back(str.substr(previous, current - previous));
-
+    
     return out;
 }
 
@@ -197,36 +197,36 @@ static std::map<std::string, std::map<std::string, std::string>> parseIni(const 
 std::map<std::string, std::map<std::string, std::string>> getParsedDataFromIniFile(const std::string& configIniPath) {
     std::map<std::string, std::map<std::string, std::string>> parsedData;
     std::string currentSection = ""; // Initialize the current section as empty
-
+    
     FILE* configFileIn = fopen(configIniPath.c_str(), "rb");
     if (!configFileIn) {
         return parsedData;
     }
-
+    
     // Determine the size of the INI file
     fseek(configFileIn, 0, SEEK_END);
     long fileSize = ftell(configFileIn);
     rewind(configFileIn);
-
+    
     // Read the contents of the INI file
     char* fileData = new char[fileSize + 1];
     fread(fileData, sizeof(char), fileSize, configFileIn);
     fileData[fileSize] = '\0';  // Add null-terminator to create a C-string
     fclose(configFileIn);
-
+    
     // Parse the INI data
     std::string fileDataString(fileData, fileSize);
-
+    
     // Normalize line endings to \n
     fileDataString.erase(std::remove(fileDataString.begin(), fileDataString.end(), '\r'), fileDataString.end());
-
+    
     // Split lines and parse
     std::istringstream fileStream(fileDataString);
     std::string line;
     while (std::getline(fileStream, line)) {
         // Remove leading and trailing whitespace
         line = trim(line);
-
+        
         // Check if this line is a section
         if (line.size() > 2 && line.front() == '[' && line.back() == ']') {
             // Remove the brackets to get the section name
@@ -237,15 +237,15 @@ std::map<std::string, std::map<std::string, std::string>> getParsedDataFromIniFi
             if (delimiterPos != std::string::npos) {
                 std::string key = trim(line.substr(0, delimiterPos));
                 std::string value = trim(line.substr(delimiterPos + 1));
-
+                
                 // Store in the current section
                 parsedData[currentSection][key] = value;
             }
         }
     }
-
+    
     delete[] fileData;
-
+    
     return parsedData;
 }
 
@@ -261,23 +261,23 @@ std::map<std::string, std::map<std::string, std::string>> getParsedDataFromIniFi
  */
 std::vector<std::string> parseSectionsFromIni(const std::string& filePath) {
     std::vector<std::string> sections;
-
+    
     FILE* file = fopen(filePath.c_str(), "r");
     if (file == nullptr) {
         return sections; // Return an empty list if the file cannot be opened
     }
-
+    
     char line[4096];
     while (fgets(line, sizeof(line), file)) {
         std::string trimmedLine = trim(std::string(line));
-
+        
         if (!trimmedLine.empty() && trimmedLine[0] == '[' && trimmedLine.back() == ']') {
             // Extract section name and add it to the list
             std::string sectionName = trimmedLine.substr(1, trimmedLine.size() - 2);
             sections.push_back(sectionName);
         }
     }
-
+    
     fclose(file);
     return sections;
 }
@@ -294,7 +294,7 @@ std::vector<std::string> parseSectionsFromIni(const std::string& filePath) {
  */
 std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> loadOptionsFromIni(const std::string& configIniPath, bool makeConfig = false) {
     std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> options;
-
+    
     FILE* configFile = fopen(configIniPath.c_str(), "r");
     if (!configFile ) {
         // Write the default INI file
@@ -314,20 +314,26 @@ std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> loadO
         fclose(configFileOut);
         configFile = fopen(configIniPath.c_str(), "r");
     }
-
+    
     constexpr size_t BufferSize = 131072; // Choose a larger buffer size for reading lines
     char line[BufferSize];
     std::string currentOption;
     std::vector<std::vector<std::string>> commands;
-
+    
+    bool isFirstEntry = true;
     while (fgets(line, sizeof(line), configFile)) {
         std::string trimmedLine = line;
         trimmedLine.erase(trimmedLine.find_last_not_of("\r\n") + 1);  // Remove trailing newline character
-
+        
         if (trimmedLine.empty() || trimmedLine[0] == '#') {
             // Skip empty lines and comment lines
             continue;
         } else if (trimmedLine[0] == '[' && trimmedLine.back() == ']') {
+            if (isFirstEntry) { // for preventing header comments from being loaded within the first command section
+                commands.clear();
+                isFirstEntry = false;
+            }
+            
             // New option section
             if (!currentOption.empty()) {
                 // Store previous option and its commands
@@ -360,12 +366,12 @@ std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> loadO
             commands.push_back(std::move(commandParts));
         }
     }
-
+    
     // Store the last option and its commands
     if (!currentOption.empty()) {
         options.emplace_back(std::move(currentOption), std::move(commands));
     }
-
+    
     fclose(configFile);
     return options;
 }
@@ -387,7 +393,7 @@ void cleanIniFormatting(const std::string& filePath) {
         // Handle the error accordingly
         return;
     }
-
+    
     std::string tempPath = filePath + ".tmp";
     FILE* outputFile = fopen(tempPath.c_str(), "w");
     if (!outputFile) {
@@ -396,13 +402,13 @@ void cleanIniFormatting(const std::string& filePath) {
         fclose(inputFile);
         return;
     }
-
+    
     bool isNewSection = false;
-
+    
     char line[4096];
     while (fgets(line, sizeof(line), inputFile)) {
         std::string trimmedLine = trim(std::string(line));
-
+        
         if (!trimmedLine.empty()) {
             if (trimmedLine[0] == '[' && trimmedLine[trimmedLine.length() - 1] == ']') {
                 if (isNewSection) {
@@ -410,14 +416,14 @@ void cleanIniFormatting(const std::string& filePath) {
                 }
                 isNewSection = true;
             }
-
+            
             fprintf(outputFile, "%s\n", trimmedLine.c_str());
         }
     }
-
+    
     fclose(inputFile);
     fclose(outputFile);
-
+    
     // Remove the original file and rename the temp file
     remove(filePath.c_str());
     rename(tempPath.c_str(), filePath.c_str());
@@ -454,11 +460,11 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
         // printf("INI file created successfully.\n");
         return;
     }
-
+    
     std::string trimmedLine;
     std::string tempPath = fileToEdit + ".tmp";
     FILE* tempFile = fopen(tempPath.c_str(), "w");
-
+    
     if (tempFile) {
         std::string currentSection;
         std::string formattedDesiredValue = removeQuotes(desiredValue);
@@ -469,7 +475,7 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
         bool keyFound = false;
         while (fgets(line, sizeof(line), configFile)) {
             trimmedLine = trim(std::string(line));
-
+            
             // Check if the line represents a section
             if (trimmedLine[0] == '[' && trimmedLine[trimmedLine.length() - 1] == ']') {
                 currentSection = removeQuotes(trim(std::string(trimmedLine.c_str() + 1, trimmedLine.length() - 2)));
@@ -482,14 +488,14 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
                 }
                 
             }
-
+            
             if (sectionFound && !keyFound && desiredNewKey.empty()) {
                 if (trim(currentSection) != trim(desiredSection)) {
                     fprintf(tempFile, "%s = %s\n", desiredKey.c_str(), formattedDesiredValue.c_str());
                     keyFound = true;
                 }
             }
-
+            
             // Check if the line is in the desired section
             if (trim(currentSection) == trim(desiredSection)) {
                 sectionFound = true;
@@ -497,12 +503,12 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
                 std::string::size_type delimiterPos = trimmedLine.find('=');
                 if (delimiterPos != std::string::npos) {
                     std::string lineKey = trim(trimmedLine.substr(0, delimiterPos));
-
+                    
                     // Check if the line key matches the desired key
                     if (lineKey == desiredKey) {
                         keyFound = true;
                         std::string originalValue = getValueFromLine(trimmedLine); // Extract the original value
-
+                        
                         // Write the modified line with the desired key and value
                         if (!desiredNewKey.empty()) {
                             fprintf(tempFile, "%s = %s\n", desiredNewKey.c_str(), originalValue.c_str());
@@ -531,7 +537,7 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
         fclose(tempFile);
         remove(fileToEdit.c_str()); // Delete the old configuration file
         rename(tempPath.c_str(), fileToEdit.c_str()); // Rename the temp file to the original name
-
+        
         // printf("INI file updated successfully.\n");
     } else {
         // printf("Failed to create temporary file.\n");
@@ -657,7 +663,7 @@ void renameIniSection(const std::string& filePath, const std::string& currentSec
         // The INI file doesn't exist, handle the error accordingly
         return;
     }
-
+    
     std::string tempPath = filePath + ".tmp";
     FILE* tempFile = fopen(tempPath.c_str(), "w");
     if (!tempFile) {
@@ -665,19 +671,19 @@ void renameIniSection(const std::string& filePath, const std::string& currentSec
         fclose(configFile);
         return;
     }
-
+    
     std::string currentSection;
     bool renaming = false;
     constexpr size_t BufferSize = 4096;
     char line[BufferSize];
-
+    
     while (fgets(line, sizeof(line), configFile)) {
         std::string currentLine(line);
-
+        
         // Check if the line represents a section
         if (currentLine.length() > 2 && currentLine.front() == '[' && currentLine.back() == ']') {
             std::string sectionName = currentLine.substr(1, currentLine.size() - 2);
-
+            
             if (sectionName == currentSectionName) {
                 // We found the section to rename
                 fprintf(tempFile, "[%s]\n", newSectionName.c_str());
@@ -696,16 +702,16 @@ void renameIniSection(const std::string& filePath, const std::string& currentSec
             fprintf(tempFile, "%s", currentLine.c_str());
         }
     }
-
+    
     fclose(configFile);
     fclose(tempFile);
-
+    
     // Replace the original file with the temp file
     if (remove(filePath.c_str()) != 0) {
         // Failed to delete the original file, handle the error accordingly
         return;
     }
-
+    
     if (rename(tempPath.c_str(), filePath.c_str()) != 0) {
         // Failed to rename the temp file, handle the error accordingly
     }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -57,11 +57,11 @@ static std::unordered_map<std::string, std::string> selectedFooterDict;
 static auto selectedListItem = new tsl::elm::ListItem("");
 static auto lastSelectedListItem = new tsl::elm::ListItem("");
 
-// Pre-defined symbols
-static std::string OPTION_SYMBOL = "\u22EF";
-static std::string DROPDOWN_SYMBOL = "\u25B6";
-static std::string CHECKMARK_SYMBOL = "\uE14B";
-static std::string STAR_SYMBOL = "\u2605";
+// Pre-defined symbols (moved to libTesla)
+//static std::string OPTION_SYMBOL = "\u22EF";
+//static std::string DROPDOWN_SYMBOL = "\u25B6";
+//static std::string CHECKMARK_SYMBOL = "\uE14B";
+//static std::string STAR_SYMBOL = "\u2605";
 
 /**
  * @brief The `ConfigOverlay` class handles configuration overlay functionality.
@@ -566,13 +566,28 @@ public:
                 }
                 auto listItem = new tsl::elm::ListItem(optionName);
                 
-                
-                if (selectedFooterDict[specificKey] == selectedItem) {
-                    lastSelectedListItem = listItem;
-                    listItem->setValue(CHECKMARK_SYMBOL);
+                if (commandMode == "option") {
+                    if (selectedFooterDict[specificKey] == selectedItem) {
+                        lastSelectedListItem = listItem;
+                        listItem->setValue(CHECKMARK_SYMBOL);
+                    } else {
+                        listItem->setValue(footer);
+                    }
                 } else {
                     listItem->setValue(footer, true);
                 }
+                
+                //if ((commandMode == "option") && selectedFooterDict[specificKey] == selectedItem) {
+                //    lastSelectedListItem = listItem;
+                //    listItem->setValue(CHECKMARK_SYMBOL);
+                //} else {
+                //    if (commandMode == "option") {
+                //        listItem->setValue(footer);
+                //    } else {
+                //        listItem->setValue(footer, true);
+                //    }
+                //    
+                //}
                 
                 //listItem->setValue(footer, true);
                 
@@ -688,7 +703,7 @@ public:
                             if (optionSection.count("footer") > 0) {
                                 auto& commandFooter = optionSection["footer"];
                                 if (commandFooter != "null") {
-                                    selectedListItem->setValue(commandFooter, true);
+                                    selectedListItem->setValue(commandFooter);
                                 }
                             }
                         }
@@ -766,7 +781,7 @@ public:
         
         // Populate the sub menu with options
         //for (const auto& option : options) {
-        size_t section_count = 0;
+        
         for (size_t i = 0; i < options.size(); ++i) {
             auto& option = options[i];
             
@@ -937,7 +952,12 @@ public:
                     listItem = new tsl::elm::ListItem(optionName, footer);
                 } else {
                     listItem = new tsl::elm::ListItem(optionName);
-                    listItem->setValue(footer, true);
+                    if (commandMode == "option") {
+                        listItem->setValue(footer);
+                    } else {
+                        listItem->setValue(footer, true);
+                    }
+                    
                 }
                 
                 //std::vector<std::vector<std::string>> modifiedCommands = getModifyCommands(option.second, pathReplace);
@@ -975,7 +995,12 @@ public:
                 
                 if (commandMode == "default" || commandMode == "option") { // for handiling toggles
                     auto listItem = new tsl::elm::ListItem(optionName);
-                    listItem->setValue(footer, true);
+                    if (commandMode == "default") {
+                        listItem->setValue(footer, true);
+                    } else {
+                        listItem->setValue(footer);
+                    }
+                    
                     
                     if (sourceType == "json") { // For JSON wildcards
                         listItem->setClickListener([this, cmds=commands, subPath = this->subPath, keyName = option.first, selectedItem, listItem](uint64_t keys) { // Add 'command' to the capture list

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -57,6 +57,12 @@ static std::unordered_map<std::string, std::string> selectedFooterDict;
 static auto selectedListItem = new tsl::elm::ListItem("");
 static auto lastSelectedListItem = new tsl::elm::ListItem("");
 
+// Pre-defined symbols
+static std::string OPTION_SYMBOL = "\u22EF";
+static std::string DROPDOWN_SYMBOL = "\u25B6";
+static std::string CHECKMARK_SYMBOL = "\uE14B";
+static std::string STAR_SYMBOL = "\u2605";
+
 /**
  * @brief The `ConfigOverlay` class handles configuration overlay functionality.
  *
@@ -159,7 +165,7 @@ public:
                             
                             commandVec.emplace_back(std::move(commandParts));
                             interpretAndExecuteCommand(commandVec);
-                            listItem->setValue("\uE14B");
+                            listItem->setValue(CHECKMARK_SYMBOL);
                             return true;
                         }
                         return false;
@@ -563,7 +569,7 @@ public:
                 
                 if (selectedFooterDict[specificKey] == selectedItem) {
                     lastSelectedListItem = listItem;
-                    listItem->setValue("\uE14B");
+                    listItem->setValue(CHECKMARK_SYMBOL);
                 } else {
                     listItem->setValue(footer, true);
                 }
@@ -582,7 +588,7 @@ public:
                             //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                             interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                             
-                            listItem->setValue("\uE14B");
+                            listItem->setValue(CHECKMARK_SYMBOL);
                             
                             if (commandMode == "option") {
                                 lastSelectedListItem = listItem;
@@ -605,7 +611,7 @@ public:
                             //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                             interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                             
-                            listItem->setValue("\uE14B");
+                            listItem->setValue(CHECKMARK_SYMBOL);
                             
                             if (commandMode == "option") {
                                 lastSelectedListItem = listItem;
@@ -752,8 +758,6 @@ public:
         rootFrame = new tsl::elm::OverlayFrame(getNameFromPath(subPath), "Ultrahand Package");
         list = new tsl::elm::List();
         
-        // Add a section break with small text to indicate the "Commands" section
-        list->addItem(new tsl::elm::CategoryHeader("Commands"));
         
         // Load options from INI file in the subdirectory
         std::string packageIniPath = subPath + packageFileName;
@@ -761,7 +765,11 @@ public:
         std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> options = loadOptionsFromIni(packageIniPath);
         
         // Populate the sub menu with options
-        for (const auto& option : options) {
+        //for (const auto& option : options) {
+        size_t section_count = 0;
+        for (size_t i = 0; i < options.size(); ++i) {
+            auto& option = options[i];
+            
             std::string optionName = option.first;
             auto commands = option.second;
             
@@ -774,7 +782,7 @@ public:
             std::string commandGrouping = "default";
             
             std::string currentSection = "global";
-            std::string sourceType = "default", sourceTypeOn = "default", sourceTypeOff = "default"; 
+            std::string sourceType = "default", sourceTypeOn = "default", sourceTypeOff = "default"; //"file", "json_file", "json", "list"
             //std::string sourceType, sourceTypeOn, sourceTypeOff; //"file", "json_file", "json", "list"
             std::string jsonPath, jsonPathOn, jsonPathOff;
             std::string jsonKey, jsonKeyOn, jsonKeyOff;
@@ -786,6 +794,22 @@ public:
             
             // items can be paths, commands, or variables depending on source
             //std::vector<std::string> selectedItemsList, selectedItemsListOn, selectedItemsListOff;
+            
+            if (commands.size() == 0) {
+                // Add a section break with small text to indicate the "Commands" section
+                list->addItem(new tsl::elm::CategoryHeader(optionName));
+                continue;
+            } else if (i == 0) {
+                // Add a section break with small text to indicate the "Commands" section
+                list->addItem(new tsl::elm::CategoryHeader("Commands"));
+            }
+            //if (optionName == "Section 1") {
+            //    for (const auto& cmd : commands) {
+            //        for (const auto& x : cmd) {
+            //            logMessage("Commands: "+x);
+            //        }
+            //    }
+            //}
             
             // initial processing of commands
             for (const auto& cmd : commands) {
@@ -888,7 +912,7 @@ public:
             if (optionName[0] == '*') { 
                 useSelection = true;
                 optionName = optionName.substr(1); // Strip the "*" character on the left
-                footer = "\u25B6";
+                footer = DROPDOWN_SYMBOL;
             } else {
                 size_t pos = optionName.find(" - ");
                 if (pos != std::string::npos) {
@@ -902,14 +926,14 @@ public:
                 if (commandFooter != "null") {
                     footer = commandFooter;
                 } else {
-                    footer = "\u22EF";
+                    footer = OPTION_SYMBOL;
                 }
             }
             
             
             if (useSelection) { // For wildcard commands (dropdown menus)
                 auto listItem = static_cast<tsl::elm::ListItem*>(nullptr);
-                if ((footer == "\u25B6") || (footer.empty())) {
+                if ((footer == DROPDOWN_SYMBOL) || (footer.empty())) {
                     listItem = new tsl::elm::ListItem(optionName, footer);
                 } else {
                     listItem = new tsl::elm::ListItem(optionName);
@@ -960,7 +984,7 @@ public:
                                 //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                                 interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                                 
-                                listItem->setValue("\uE14B");
+                                listItem->setValue(CHECKMARK_SYMBOL);
                                 return true;
                             }  else if (keys & KEY_X) {
                                 inSubMenu = false; // Set boolean to true when entering a submenu
@@ -978,7 +1002,7 @@ public:
                                 //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                                 interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                                 
-                                listItem->setValue("\uE14B");
+                                listItem->setValue(CHECKMARK_SYMBOL);
                                 return true;
                             }  else if (keys & KEY_X) {
                                 inSubMenu = false; // Set boolean to true when entering a submenu
@@ -1165,7 +1189,6 @@ private:
     std::string packageIniPath = packageDirectory + packageFileName;
     std::string packageConfigIniPath = packageDirectory + configFileName;
     std::string menuMode, defaultMenuMode, inOverlayString, fullPath, optionName, hideOverlayVersions, hidePackageVersions, priority, starred;
-    std::string STAR_HEADER = "\u2605 ";
     bool useDefaultMenu = false;
     
     
@@ -1365,7 +1388,7 @@ public:
                     
                     std::string newOverlayName = overlayName.c_str();
                     if (overlayStarred == "true") {
-                        newOverlayName = STAR_HEADER+newOverlayName;
+                        newOverlayName = STAR_SYMBOL+" "+newOverlayName;
                     }
                     
                     
@@ -1494,7 +1517,7 @@ public:
                 
                 std::string newPackageName = packageName.c_str();
                 if (packageStarred == "true") {
-                    newPackageName = STAR_HEADER+newPackageName;
+                    newPackageName = STAR_SYMBOL+" "+newPackageName;
                 }
                 
                 std::string packageFilePath = packageDirectory + packageName+ "/";
@@ -1552,9 +1575,6 @@ public:
             
             for (size_t i = 0; i < options.size(); ++i) {
                 auto option = options[i];
-                if (i == 0) {
-                    list->addItem(new tsl::elm::CategoryHeader("Commands"));
-                }
                 
                 std::string optionName = option.first;
                 auto commands = option.second;
@@ -1579,8 +1599,14 @@ public:
                 std::vector<std::string> listData, listDataOn, listDataOff;
                 
                 
-                //write a copy of optionName to packageConfigIniPath if it does not exist between []
-                //initialize default values for keys mode
+                if (commands.size() == 0) {
+                    // Add a section break with small text to indicate the "Commands" section
+                    list->addItem(new tsl::elm::CategoryHeader(optionName));
+                    continue;
+                } else if (i == 0) {
+                    // Add a section break with small text to indicate the "Commands" section
+                    list->addItem(new tsl::elm::CategoryHeader("Commands"));
+                }
                 
                 
                 
@@ -1693,7 +1719,7 @@ public:
                 if (optionName[0] == '*') { 
                     useSelection = true;
                     optionName = optionName.substr(1); // Strip the "*" character on the left
-                    footer = "\u25B6";
+                    footer = DROPDOWN_SYMBOL;
                 } else {
                     size_t pos = optionName.find(" - ");
                     if (pos != std::string::npos) {
@@ -1710,7 +1736,7 @@ public:
                 
                 if (useSelection) { // For wildcard commands (dropdown menus)
                     auto listItem = static_cast<tsl::elm::ListItem*>(nullptr);
-                    if ((footer == "\u25B6") || (footer.empty())) {
+                    if ((footer == DROPDOWN_SYMBOL) || (footer.empty())) {
                         listItem = new tsl::elm::ListItem(optionName, footer);
                     } else {
                         listItem = new tsl::elm::ListItem(optionName);
@@ -1755,7 +1781,7 @@ public:
                                     //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                                     interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                                     
-                                    listItem->setValue("\uE14B");
+                                    listItem->setValue(CHECKMARK_SYMBOL);
                                     return true;
                                 }  else if (keys & KEY_X) {
                                     inMainMenu = false; // Set boolean to true when entering a submenu
@@ -1773,7 +1799,7 @@ public:
                                     //modifiedCmds = getSecondaryReplacement(modifiedCmds); // replace list and json
                                     interpretAndExecuteCommand(modifiedCmds); // Execute modified 
                                     
-                                    listItem->setValue("\uE14B");
+                                    listItem->setValue(CHECKMARK_SYMBOL);
                                     return true;
                                 }  else if (keys & KEY_X) {
                                     inMainMenu = false; // Set boolean to true when entering a submenu


### PR DESCRIPTION
List of changes:
1. Empty commands now define grouping sections.
2. Empty commands with a `*` at the start of them define group commands.  Commands defined after will show up in a dropdown menu.
3. To end the identification of a group command, a group section must be defined.

Basic package example:
```ini
[Section 1]
[*Test]
;mode=option
list_source '(test1, test2, test3)'
set-ini-val '/switch/.packages/Test/config.ini' *Test footer {list_source(*)}

[*Timings]
;mode=option
list_source '(1, 2, 3, 4, 5, 6)'
set-ini-val '/switch/.packages/Test/config.ini' *Timing footer {list_source(*)}

[*Commands Group]
[*Test2]
json_source '[{"key_1":"entry 1", "key_2":"entry 2", "key_3":"entry 3"}, {"key_1":"entry a", "key_2":"entry b", "key_3":"entry c"}]' key_1

[Section 1]
[*Test3]
;mode=option
list_source '(test4, test5, test6)'
set-ini-val '/switch/.packages/Test/config.ini' *Test3 footer {list_source(*)}
```