### PR TITLE
Development for v1.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= ppkantorski
-APP_VERSION	:= 1.6.0
+APP_VERSION	:= 1.6.1
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -3886,7 +3886,7 @@ namespace tsl {
                     this->updateScrollOffset();
                 }
 
-                renderer->enableScissoring(this->getLeftBound(), this->getTopBound(), this->getWidth()+2, this->getHeight() + 4);
+                renderer->enableScissoring(this->getLeftBound(), this->getTopBound(), this->getWidth()+2+2, this->getHeight() + 4);
 
                 for (auto &entry : this->m_items) {
                     if (entry->getBottomBound() > this->getTopBound() && entry->getTopBound() < this->getBottomBound()) {
@@ -4351,7 +4351,7 @@ namespace tsl {
             }
             
             virtual void layout(u16 parentX, u16 parentY, u16 parentWidth, u16 parentHeight) override {
-                this->setBoundaries(this->getX()+2, this->getY(), this->getWidth()+8, tsl::style::ListItemDefaultHeight);
+                this->setBoundaries(this->getX()+2+1, this->getY(), this->getWidth()+8+1, tsl::style::ListItemDefaultHeight);
             }
             
             virtual bool onClick(u64 keys) override {
@@ -4543,8 +4543,8 @@ namespace tsl {
             virtual ~CategoryHeader() {}
             
             virtual void draw(gfx::Renderer *renderer) override {
-                renderer->drawRect(this->getX()+1, this->getBottomBound() - 30, 3, 23, a(defaultTextColor));
-                renderer->drawString(this->m_text.c_str(), false, this->getX() + 15, this->getBottomBound() - 12, 15, a(defaultTextColor));
+                renderer->drawRect(this->getX()+1+1, this->getBottomBound() - 30, 3, 23, a(defaultTextColor));
+                renderer->drawString(this->m_text.c_str(), false, this->getX() + 15+1, this->getBottomBound() - 12, 15, a(defaultTextColor));
                 
                 //if (this->m_hasSeparator)
                 //    renderer->drawRect(this->getX(), this->getBottomBound(), this->getWidth(), 1, tsl::style::color::ColorFrame); // CUSTOM MODIFICATION

--- a/lib/libultra/include/ultra.hpp
+++ b/lib/libultra/include/ultra.hpp
@@ -83,6 +83,7 @@ const std::string TRUE_STR = "true";
 const std::string FALSE_STR = "false";
 const std::string GLOBAL_STR = "global";
 const std::string DEFAULT_STR = "default";
+const std::string SLOT_STR = "slot";
 const std::string OPTION_STR = "option";
 const std::string FORWARDER_STR = "forwarder";
 const std::string TEXT_STR = "text";
@@ -90,6 +91,7 @@ const std::string TABLE_STR = "table";
 const std::string NULL_STR = "null";
 const std::string THEME_STR = "theme";
 const std::string NOT_AVAILABLE_STR = "Not available";
+
 
 // Include all functional headers used in the libUltra library
 #include "debug_funcs.hpp"


### PR DESCRIPTION
List of changes:
1. New command mode `;mode=slot` for slot commands.
    - `slot` commands are similar to `default`, but with the ability to set footers (similar to an `option` command).
2. Various placeholder replacement bug fixes.
    - Preservation of `null` arg with default to `Not available` upon final replacement.
    - Placeholder replacements now no longer contribute to command success/failure. (determined now solely by commands themselves.)
3. Hex edits will now be unprocessed for `null` arguments and still return successful. (bug fix)
4. New placeholder `{timestamp(<strftime>)}` for logging time as a variable.
    - `strftime` are datetime formats like `"%Y-%m-%d"`.
5. Nested layers bug fix (for nested layers beyond layer #1).
6. Package forwarder bug fixes.
7. Slight tweaks to libtesla.