### PR TITLE
Development for v1.6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= ppkantorski
-APP_VERSION	:= 1.6.3
+APP_VERSION	:= 1.6.4
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -3779,7 +3779,7 @@ namespace tsl {
 
                 selectWidth = renderer->calculateStringWidth(OK, 23);
                 if (touchingSelect) {
-                    renderer->drawRoundedRect(backWidth+86.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
+                    renderer->drawRoundedRect(18.0f + backWidth+68.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
                                               selectWidth+68.0f, 73.0f, 6.0f, a(clickColor));
                 }
                 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4803,7 +4803,7 @@ namespace tsl {
                 return this;
             }
 
-            void updateAndExecute() {
+            inline void updateAndExecute(bool updateIni = true) {
                 if (m_packagePath.empty()) {
                     return;
                 }
@@ -4811,9 +4811,11 @@ namespace tsl {
                 std::string indexStr = std::to_string(m_index);
                 std::string valueStr = m_usingNamedStepTrackbar ? m_selection : std::to_string(m_value);
                 
-                setIniFileValue(m_packagePath + "config.ini", m_label, "index", indexStr);
-                setIniFileValue(m_packagePath + "config.ini", m_label, "value", valueStr);
-                
+                if (updateIni) {
+                    setIniFileValue(m_packagePath + "config.ini", m_label, "index", indexStr);
+                    setIniFileValue(m_packagePath + "config.ini", m_label, "value", valueStr);
+                }
+
                 if (interpretAndExecuteCommands) {
                     auto commandsCopy = commands;
                     size_t pos;
@@ -4861,8 +4863,8 @@ namespace tsl {
                 // Allow sliding only if KEY_A has been pressed
                 if (allowSlide || m_unlockedTrackbar) {
                     if ((keysReleased & HidNpadButton_AnyLeft) || (keysReleased & HidNpadButton_AnyRight)) {
-                        if (!m_executeOnEveryTick)
-                            updateAndExecute();
+                        //if (!m_executeOnEveryTick)
+                        updateAndExecute();
                         holding = false;
                         return true;
                     }
@@ -4894,7 +4896,7 @@ namespace tsl {
                                     this->m_value--;
                                     this->m_valueChangedListener(this->m_value);
                                     if (m_executeOnEveryTick) {
-                                        updateAndExecute();
+                                        updateAndExecute(false);
                                     }
                                     lastUpdate = now;
                                     return true;
@@ -4907,7 +4909,7 @@ namespace tsl {
                                     this->m_value++;
                                     this->m_valueChangedListener(this->m_value);
                                     if (m_executeOnEveryTick) {
-                                        updateAndExecute();
+                                        updateAndExecute(false);
                                     }
                                     lastUpdate = now;
                                     return true;
@@ -4940,8 +4942,8 @@ namespace tsl {
                 //    event = TouchEvent::Release;
                 //}
                 if (event == TouchEvent::Release) {
-                    if (!m_executeOnEveryTick)
-                        updateAndExecute();
+                    //if (!m_executeOnEveryTick)
+                    updateAndExecute();
                     this->m_interactionLocked = false;
                     touchInSliderBounds = false;
                     return false;
@@ -4967,7 +4969,7 @@ namespace tsl {
                         this->m_index = newIndex;
                         this->m_valueChangedListener(this->getProgress());
                         if (m_executeOnEveryTick) {
-                            updateAndExecute();
+                            updateAndExecute(false);
                         }
                     }
                     
@@ -4983,7 +4985,7 @@ namespace tsl {
 
 
             // Define drawBar function outside the draw method
-            void drawBar(gfx::Renderer *renderer, s32 x, s32 y, u16 width, Color color, bool isRounded = true) {
+            inline void drawBar(gfx::Renderer *renderer, s32 x, s32 y, u16 width, Color color, bool isRounded = true) {
                 if (isRounded) {
                     renderer->drawUniformRoundedRect(x, y, width, 7, a(color));
                 } else {
@@ -5193,7 +5195,7 @@ namespace tsl {
                 u64 keysReleased = prevKeysHeld & ~keysHeld;
                 prevKeysHeld = keysHeld;
                 //static bool usingUnlockedTrackbar = m_unlockedTrackbar;
-
+                
                 // Check if KEY_A is pressed to toggle allowSlide
                 if ((keysDown & KEY_A)) {
                     if (!m_unlockedTrackbar) {
@@ -5205,11 +5207,11 @@ namespace tsl {
                     }
                     return true;
                 }
-
+                
                 if (allowSlide || m_unlockedTrackbar) {
                     if ((keysReleased & HidNpadButton_AnyLeft) || (keysReleased & HidNpadButton_AnyRight)) {
-                        if (!m_executeOnEveryTick)
-                            updateAndExecute();
+                        //if (!m_executeOnEveryTick)
+                        updateAndExecute();
                         holding = false;
                         tick = 0;
                         return true;
@@ -5241,7 +5243,7 @@ namespace tsl {
                             }
                             this->m_valueChangedListener(this->getProgress());
                             if (m_executeOnEveryTick)
-                                updateAndExecute();
+                                updateAndExecute(false);
                         }
                         tick++;
                         return true;
@@ -5341,7 +5343,7 @@ namespace tsl {
                 u16 baseY = this->getY() + 44; // 50 - 3
                 // Calculate the halfway point
                 u8 halfNumSteps = (this->m_numSteps - 1) / 2;
-                
+
                 // Draw step rectangles
                 for (u8 i = 0; i < this->m_numSteps; i++) {
                     u16 stepX = baseX + std::round(i * (trackBarWidth / (this->m_numSteps - 1)));
@@ -5358,7 +5360,7 @@ namespace tsl {
                 // Draw the parent trackbar
                 StepTrackBar::draw(renderer);
             }
-            
+
             
         protected:
             std::vector<std::string> m_stepDescriptions;

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -756,6 +756,7 @@ std::map<std::string, std::string> defaultThemeSettingsMap = {
     {"table_bg_alpha", "10"},
     {"table_section_text_color", whiteColor},
     {"table_info_text_color", "#00FFDD"},
+    {"warning_text_color", "#FF7777"},
     {"trackbar_slider_color", "#606060"},
     {"trackbar_slider_border_color", "#505050"},
     {"trackbar_slider_malleable_color", "#A0A0A0"},
@@ -776,7 +777,7 @@ std::map<std::string, std::string> defaultThemeSettingsMap = {
     {"highlight_color_4", "#F7253E"},
     {"click_text_color", whiteColor},
     {"click_alpha", "7"},
-    {"click_color", "#F7253E"},
+    {"click_color", "#3E25F7"},
     {"invert_bg_click_color", FALSE_STR},
     {"disable_selection_bg", FALSE_STR},
     {"disable_colorful_logo", FALSE_STR},
@@ -1239,7 +1240,7 @@ namespace tsl {
     }
 
 
-    inline Color RGB888(const std::string& hexColor, const std::string& defaultHexColor = whiteColor, size_t alpha = 15) {
+    inline Color RGB888(const std::string& hexColor, size_t alpha = 15, const std::string& defaultHexColor = whiteColor) {
         std::string validHex = hexColor.empty() || hexColor[0] != '#' ? hexColor : hexColor.substr(1);
         
         if (!isValidHexColor(validHex)) {
@@ -1308,7 +1309,7 @@ namespace tsl {
     static Color logoColor2 = RGB888("#F7253E");
     static size_t defaultBackgroundAlpha = 13;
     
-    static Color defaultBackgroundColor = RGB888(blackColor, blackColor, defaultBackgroundAlpha);
+    static Color defaultBackgroundColor = RGB888(blackColor, defaultBackgroundAlpha);
     static Color defaultTextColor = RGB888(whiteColor);
     static Color headerTextColor = RGB888(whiteColor);
     static Color headerSeparatorColor = RGB888(whiteColor);
@@ -1332,7 +1333,7 @@ namespace tsl {
     static bool invertBGClickColor = false;
 
     static size_t selectionBGAlpha = 7;
-    static Color selectionBGColor = RGB888(blackColor, blackColor, selectionBGAlpha);
+    static Color selectionBGColor = RGB888(blackColor, selectionBGAlpha);
 
     static Color highlightColor1 = RGB888("#2288CC");
     static Color highlightColor2 = RGB888("#88FFFF");
@@ -1343,21 +1344,22 @@ namespace tsl {
     
     static size_t clickAlpha = 7;
 
-    static Color clickColor = RGB888("#F7253E", "#F7253E", clickAlpha);
+    static Color clickColor = RGB888("#3E25F7", clickAlpha);
     static Color trackBarColor = RGB888("#555555");
 
     static size_t separatorAlpha = 15;
     
-    static Color separatorColor = RGB888("#404040", "#404040", separatorAlpha);
+    static Color separatorColor = RGB888("#404040", separatorAlpha);
     static Color selectedTextColor = RGB888(whiteColor);
     static Color inprogressTextColor = RGB888(whiteColor);
     static Color invalidTextColor = RGB888("#FF0000");
     static Color clickTextColor = RGB888(whiteColor);
 
     static size_t tableBGAlpha = 7;
-    static Color tableBGColor = RGB888("#303030", "#303030", tableBGAlpha);
+    static Color tableBGColor = RGB888("#303030", tableBGAlpha);
     static Color sectionTextColor = RGB888("#e9ff40");
     static Color infoTextColor = RGB888(whiteColor);
+    static Color warningTextColor = RGB888("#FF7777");
 
 
     static Color trackBarSliderColor = RGB888("#606060");
@@ -1381,7 +1383,7 @@ namespace tsl {
             // Convert hex color to Color and manage default values and conversion
             auto getColor = [&](const std::string& key, size_t alpha = 15) {
                 std::string hexColor = getValue(key);
-                return RGB888(hexColor, hexColor, alpha);
+                return RGB888(hexColor, alpha);
             };
             
             auto getAlpha = [&](const std::string& key) {
@@ -1444,6 +1446,7 @@ namespace tsl {
             tableBGColor = getColor("table_bg_color", tableBGAlpha);
             sectionTextColor = getColor("table_section_text_color");
             infoTextColor = getColor("table_info_text_color");
+            warningTextColor = getColor("warning_text_color");
 
 
             trackBarSliderColor = getColor("trackbar_slider_color");
@@ -3101,7 +3104,7 @@ namespace tsl {
             virtual void drawClickAnimation(gfx::Renderer *renderer) {
                 saturation = tsl::style::ListItemHighlightSaturation * (float(this->m_clickAnimationProgress) / float(tsl::style::ListItemHighlightLength));
 
-                Color animColor = RGB888(whiteColor);
+                Color animColor = {0xF,0xF,0xF,0xF};
                 if (invertBGClickColor) {
                     animColor.r = 15-saturation;
                     animColor.g = 15-saturation;
@@ -3537,7 +3540,7 @@ namespace tsl {
             
             //std::string firstHalf, secondHalf;
             //tsl::Color handColor = RGB888("#F7253E");
-            tsl::Color titleColor = {0xF, 0xF, 0xF, 0xF};
+            tsl::Color titleColor = {0xF,0xF,0xF,0xF};
             const double cycleDuration = 1.5;
             float counter = 0;
             float countOffset;
@@ -5068,8 +5071,8 @@ namespace tsl {
                 renderer->drawString(valuePart.c_str(), false, combinedX + labelWidth, this->getY() + 14 + 16, 16, a(onTextColor));
                 
                 if (lastBottomBound != this->getTopBound())
-                    renderer->drawRect(this->getX() + 4+20, this->getTopBound(), this->getWidth() + 6 + 10+20, 1, a(separatorColor));
-                renderer->drawRect(this->getX() + 4+20, this->getBottomBound(), this->getWidth() + 6 + 10+20, 1, a(separatorColor));
+                    renderer->drawRect(this->getX() + 4+20-1, this->getTopBound(), this->getWidth() + 6 + 10+20, 1, a(separatorColor));
+                renderer->drawRect(this->getX() + 4+20-1, this->getBottomBound(), this->getWidth() + 6 + 10+20, 1, a(separatorColor));
                 lastBottomBound = this->getBottomBound();
             }
 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -64,9 +64,10 @@
 //#include <filesystem> // Comment out filesystem
 
 // CUSTOM SECTION START
-float backWidth;
-float selectWidth;
+float backWidth, selectWidth, nextPageWidth;
 static bool inMainMenu = false;
+static bool inOverlaysPage = false;
+static bool inPackagesPage = false;
 
 //static std::unordered_map<std::string, std::string> hexSumCache;
 
@@ -3772,8 +3773,8 @@ namespace tsl {
                 
                 backWidth = renderer->calculateStringWidth(BACK, 23);
                 if (touchingBack) {
-                    renderer->drawRoundedRect(0.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
-                                              backWidth+86.0f, 73.0f, 6.0f, a(clickColor));
+                    renderer->drawRoundedRect(18.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
+                                              backWidth+68.0f, 73.0f, 6.0f, a(clickColor));
                 }
 
                 selectWidth = renderer->calculateStringWidth(OK, 23);
@@ -3782,10 +3783,20 @@ namespace tsl {
                                               selectWidth+68.0f, 73.0f, 6.0f, a(clickColor));
                 }
                 
+                if (!(this->m_pageLeftName).empty())
+                    nextPageWidth = renderer->calculateStringWidth(this->m_pageLeftName, 23);
+                else if (!(this->m_pageRightName).empty())
+                    nextPageWidth = renderer->calculateStringWidth(this->m_pageRightName, 23);
+                else if (inMainMenu)
+                    if (inOverlaysPage)
+                        nextPageWidth = renderer->calculateStringWidth(PACKAGES,23);
+                    else if (inPackagesPage)
+                        nextPageWidth = renderer->calculateStringWidth(OVERLAYS,23);
+
                 if (inMainMenu || !(this->m_pageLeftName).empty() || !(this->m_pageRightName).empty()) {
                     if (touchingNextPage) {
-                        renderer->drawRoundedRect(backWidth+86.0f + selectWidth+68.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
-                                                  static_cast<float>(cfg::FramebufferWidth - (backWidth+86.0f + selectWidth+68.0f)), 73.0f, 6.0f, a(clickColor));
+                        renderer->drawRoundedRect(18.0f + backWidth+68.0f + selectWidth+68.0f, static_cast<float>(cfg::FramebufferHeight - 73), 
+                                                  nextPageWidth+70.0f, 73.0f, 6.0f, a(clickColor));
                     }
                 }
 
@@ -5982,9 +5993,9 @@ namespace tsl {
                 topElement->onTouch(elm::TouchEvent::Release, oldTouchPos.x, oldTouchPos.y, oldTouchPos.x, oldTouchPos.y, initialTouchPos.x, initialTouchPos.y);
             }
 
-            touchingBack = (touchPos.x < backWidth+86.0f && touchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x < backWidth+86.0f&& initialTouchPos.y > cfg::FramebufferHeight - 73U);
+            touchingBack = (touchPos.x >= 20.0f && touchPos.x < backWidth+86.0f && touchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >= 20.0f && initialTouchPos.x < backWidth+86.0f&& initialTouchPos.y > cfg::FramebufferHeight - 73U);
             touchingSelect = (touchPos.x >= backWidth+86.0f && touchPos.x < (backWidth+86.0f + selectWidth+68.0f) && touchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >=  backWidth+86.0f && initialTouchPos.x < (backWidth+86.0f + selectWidth+68.0f) && initialTouchPos.y > cfg::FramebufferHeight - 73U);
-            touchingNextPage = (touchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && touchPos.x <= cfg::FramebufferWidth && touchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && initialTouchPos.x <= cfg::FramebufferWidth && initialTouchPos.y > cfg::FramebufferHeight - 73U);
+            touchingNextPage = (touchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && (touchPos.x <= backWidth+86.0f + selectWidth+68.0f +nextPageWidth+70.0f) && touchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && (initialTouchPos.x <= backWidth+86.0f + selectWidth+68.0f +nextPageWidth+70.0f) && initialTouchPos.y > cfg::FramebufferHeight - 73U);
             touchingMenu = (touchPos.x > 0U && touchPos.x <= 245 && touchPos.y > 10U && touchPos.y <= 83U) && (initialTouchPos.x > 0U && initialTouchPos.x <= 245 && initialTouchPos.y > 10U && initialTouchPos.y <= 83U);
             
 
@@ -6031,16 +6042,16 @@ namespace tsl {
                 stillTouching = true;
             } else {
                 if (!interruptedTouch && !runningInterpreter.load(std::memory_order_acquire)) {
-                    if (oldTouchPos.x < 150U && oldTouchPos.y > cfg::FramebufferHeight - 73U && initialTouchPos.x < 150U && initialTouchPos.y > cfg::FramebufferHeight - 73U) {
+                    if ((oldTouchPos.x >= 20.0f && oldTouchPos.x < backWidth+86.0f && oldTouchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >= 20.0f && initialTouchPos.x < backWidth+86.0f&& initialTouchPos.y > cfg::FramebufferHeight - 73U)) {
                         simulatedBackComplete = false;
                         simulatedBack = true;
-                    } else if (oldTouchPos.x >= 150U && oldTouchPos.x < 260U && oldTouchPos.y > cfg::FramebufferHeight - 73U && initialTouchPos.x >= 150U && initialTouchPos.x < 260U && initialTouchPos.y > cfg::FramebufferHeight - 73U) {
+                    } else if ((oldTouchPos.x >= backWidth+86.0f && oldTouchPos.x < (backWidth+86.0f + selectWidth+68.0f) && oldTouchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >=  backWidth+86.0f && initialTouchPos.x < (backWidth+86.0f + selectWidth+68.0f) && initialTouchPos.y > cfg::FramebufferHeight - 73U)) {
                         simulatedSelectComplete = false;
                         simulatedSelect = true;
-                    } else if (oldTouchPos.x >= 260U && oldTouchPos.x <= cfg::FramebufferWidth && oldTouchPos.y > cfg::FramebufferHeight - 73U && initialTouchPos.x >= 260U && initialTouchPos.x <= cfg::FramebufferWidth && initialTouchPos.y > cfg::FramebufferHeight - 73U) {
+                    } else if ((oldTouchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && (oldTouchPos.x <= backWidth+86.0f + selectWidth+68.0f +nextPageWidth+70.0f) && oldTouchPos.y > cfg::FramebufferHeight - 73U) && (initialTouchPos.x >= (backWidth+86.0f + selectWidth+68.0f) && (initialTouchPos.x <= backWidth+86.0f + selectWidth+68.0f +nextPageWidth+70.0f) && initialTouchPos.y > cfg::FramebufferHeight - 73U)) {
                         simulatedNextPageComplete = false;
                         simulatedNextPage = true;
-                    } else if (oldTouchPos.x > 0U && oldTouchPos.x <= 245 && oldTouchPos.y > 0U && oldTouchPos.y <= 73U && initialTouchPos.x > 0U && initialTouchPos.x <= 245 && initialTouchPos.y > 0U && initialTouchPos.y <= 73U) {
+                    } else if ((oldTouchPos.x > 0U && oldTouchPos.x <= 245 && oldTouchPos.y > 10U && oldTouchPos.y <= 83U) && (initialTouchPos.x > 0U && initialTouchPos.x <= 245 && initialTouchPos.y > 10U && initialTouchPos.y <= 83U)) {
                         simulatedMenuComplete = false;
                         simulatedMenu = true;
                     }

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -957,7 +957,7 @@ Result tsOpenTsSession(Service* &serviceSession, TsSession* out, TsDeviceCode de
     );
 }
 
-void tsCloseTsSession(TsSession* in) {
+inline void tsCloseTsSession(TsSession* in) {
     serviceClose(&in->s);
 }
 
@@ -966,7 +966,7 @@ Result tsGetTemperatureWithTsSession(TsSession* ITs, float* temperature) {
 }
 
 
-bool thermalstatusInit(void) {
+inline bool thermalstatusInit(void) {
     tcCheck = tcInitialize();
     tsCheck = tsInitialize();
     if (R_SUCCEEDED(tsCheck)) {
@@ -977,7 +977,7 @@ bool thermalstatusInit(void) {
     return true;
 }
 
-void thermalstatusExit(void) {
+inline void thermalstatusExit(void) {
     tsExit();
     tcExit();
 }
@@ -3421,7 +3421,7 @@ namespace tsl {
              * @param a Amplitude
              * @return Damped sine wave output
              */
-            int shakeAnimation(std::chrono::system_clock::duration t, float a) {
+            inline int shakeAnimation(std::chrono::system_clock::duration t, float a) {
                 float w = 0.2F;
                 float tau = 0.05F;
                 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4717,13 +4717,16 @@ namespace tsl {
         public:
             
             
-            CategoryHeader(const std::string &title, bool hasSeparator = false) : m_text(title), m_hasSeparator(hasSeparator) {}
+            CategoryHeader(const std::string &title, bool hasSeparator = true) : m_text(title), m_hasSeparator(hasSeparator) {}
             virtual ~CategoryHeader() {}
             
             virtual void draw(gfx::Renderer *renderer) override {
-                renderer->drawRect(this->getX()+1+1, this->getBottomBound() - 30, 3, 23, a(headerSeparatorColor));
-                renderer->drawString(this->m_text.c_str(), false, this->getX() + 15+1, this->getBottomBound() - 12, 15, a(headerTextColor));
-                
+                if (this->m_hasSeparator) {
+                    renderer->drawRect(this->getX()+1+1, this->getBottomBound() - 30, 3, 23, a(headerSeparatorColor));
+                    renderer->drawString(this->m_text.c_str(), false, this->getX() + 15+1, this->getBottomBound() - 12, 15, a(headerTextColor));
+                } else {
+                    renderer->drawString(this->m_text.c_str(), false, this->getX(), this->getBottomBound() - 12, 15, a(headerTextColor));
+                }
                 //if (this->m_hasSeparator)
                 //    renderer->drawRect(this->getX(), this->getBottomBound(), this->getWidth(), 1, tsl::style::color::ColorFrame); // CUSTOM MODIFICATION
             }
@@ -4736,11 +4739,12 @@ namespace tsl {
                         return;
                     }
                 }
-                if (!m_hasSeparator) { // CUSTOM MODIFICATION
-                    this->setBoundaries(this->getX(), this->getY()-4, this->getWidth(), tsl::style::ListItemDefaultHeight *0.90); // CUSTOM MODIFICATION
-                } else {
-                    this->setBoundaries(this->getX(), this->getY()-4, this->getWidth(), tsl::style::ListItemDefaultHeight / 2); // CUSTOM MODIFICATION
-                }
+                this->setBoundaries(this->getX(), this->getY()-4, this->getWidth(), tsl::style::ListItemDefaultHeight *0.90);
+                //if (m_hasSeparator) { // CUSTOM MODIFICATION
+                //    this->setBoundaries(this->getX(), this->getY()-4, this->getWidth(), tsl::style::ListItemDefaultHeight *0.90); // CUSTOM MODIFICATION
+                //} else {
+                //    this->setBoundaries(this->getX(), this->getY()-4, this->getWidth(), tsl::style::ListItemDefaultHeight / 2); // CUSTOM MODIFICATION
+                //}
             }
             
             virtual bool onClick(u64 keys) {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -73,7 +73,8 @@ static const std::string ALIGNMENT_PATTERN = ";alignment=";
 static const std::string GAP_PATTERN =";gap=";
 static const std::string OFFSET_PATTERN = ";offset=";
 static const std::string SPACING_PATTERN = ";spacing=";
-static const std::string COLOR_MODE_PATTERN = ";color_mode=";
+static const std::string INFO_TEXT_COLOR_PATTERN = ";info_text_color=";
+static const std::string SECTION_TEXT_COLOR_PATTERN = ";section_text_color=";
 
 // Trackbar option patterns
 static const std::string MIN_VALUE_PATTERN = ";min_value=";
@@ -132,7 +133,8 @@ struct CommandOptions {
     size_t& tableEndGap;
     size_t& tableColumnOffset;
     size_t& tableSpacing;
-    std::string& tableColorMode;
+    std::string& tableSectionTextColor;
+    std::string& tableInfoTextColor;
     std::string& tableAlignment;
     s16& minValue;
     s16& maxValue;
@@ -218,8 +220,11 @@ void processCommands(CommandOptions& options, CommandData& data) {
             } else if (options.commandName.find(SPACING_PATTERN) == 0) {
                 options.tableSpacing = std::stoi(options.commandName.substr(SPACING_PATTERN.length()));
                 continue;
-            } else if (options.commandName.find(COLOR_MODE_PATTERN) == 0) {
-                options.tableColorMode = options.commandName.substr(COLOR_MODE_PATTERN.length());
+            } else if (options.commandName.find(SECTION_TEXT_COLOR_PATTERN) == 0) {
+                options.tableSectionTextColor = options.commandName.substr(SECTION_TEXT_COLOR_PATTERN.length());
+                continue;
+            } else if (options.commandName.find(INFO_TEXT_COLOR_PATTERN) == 0) {
+                options.tableInfoTextColor = options.commandName.substr(INFO_TEXT_COLOR_PATTERN.length());
                 continue;
             } else if (options.commandName.find(ALIGNMENT_PATTERN) == 0) {
                 options.tableAlignment = options.commandName.substr(ALIGNMENT_PATTERN.length());
@@ -1926,13 +1931,13 @@ public:
         
         bool hideTableBackground;
         size_t tableStartGap, tableEndGap, tableColumnOffset, tableSpacing;
-        std::string tableColorMode, tableAlignment;
+        std::string tableSectionTextColor, tableInfoTextColor, tableAlignment;
 
         // Pack variables into structs
         CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
                                   commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
                                   sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
-                                  tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableColorMode, tableAlignment,
+                                  tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment,
                                   minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
         
         CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
@@ -1952,7 +1957,8 @@ public:
             tableEndGap = 3;
             tableColumnOffset = 160;
             tableSpacing = 0;
-            tableColorMode = DEFAULT_STR;
+            tableSectionTextColor = DEFAULT_STR;
+            tableInfoTextColor = DEFAULT_STR;
             tableAlignment = RIGHT_STR;
             
             // Trackbar settings
@@ -2138,7 +2144,7 @@ public:
                 
                 if (!skipSection && !skipSystem) { // for skipping the drawing of sections
                     if (commandMode == TABLE_STR) {
-                        addTable(list, tableData, this->packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
+                        addTable(list, tableData, this->packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground);
                         continue;
                     } else if (commandMode == TRACKBAR_STR) {
                         list->addItem(new tsl::elm::TrackBar(optionName, this->packagePath, minValue, maxValue, units, interpretAndExecuteCommands, commands, option.first, false, false, -1, unlockedTrackbar, onEveryTick));
@@ -2863,6 +2869,8 @@ public:
         
         // Overlays menu
         if (menuMode == OVERLAYS_STR) {
+            inOverlaysPage = true;
+            inPackagesPage = false;
             //closeInterpreterThread();
 
             list->addItem(new tsl::elm::CategoryHeader(!inHiddenMode ? OVERLAYS : HIDDEN_OVERLAYS));
@@ -3124,7 +3132,8 @@ public:
         
         // Packages menu
         if (menuMode == PACKAGES_STR ) {
-            
+            inOverlaysPage = false;
+            inPackagesPage = true;
 
             if (dropdownSection.empty()) {
                 // Create the directory if it doesn't exist
@@ -3397,7 +3406,7 @@ public:
 
                 bool hideTableBackground;
                 size_t tableStartGap, tableEndGap, tableColumnOffset, tableSpacing;
-                std::string tableColorMode, tableAlignment;
+                std::string tableSectionTextColor, tableInfoTextColor, tableAlignment;
                 
                 s16 minValue;
                 s16 maxValue;
@@ -3412,7 +3421,7 @@ public:
                 CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
                                           commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
                                           sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
-                                          tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableColorMode, tableAlignment,
+                                          tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment,
                                           minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
                 
                 CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
@@ -3431,7 +3440,8 @@ public:
                     tableEndGap = 3;
                     tableColumnOffset = 160;
                     tableSpacing = 0;
-                    tableColorMode = DEFAULT_STR;
+                    tableSectionTextColor = DEFAULT_STR;
+                    tableInfoTextColor = DEFAULT_STR;
                     tableAlignment = RIGHT_STR;
                     
                     minValue = 0;
@@ -3574,7 +3584,7 @@ public:
                     
                     if (!skipSection && !skipSystem) {
                         if (commandMode == TABLE_STR) {
-                            addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
+                            addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground);
                             continue;
                         } else if (commandMode == TRACKBAR_STR) {
                             list->addItem(new tsl::elm::TrackBar(optionName, packagePath, minValue, maxValue, units, interpretAndExecuteCommands, commands, option.first, false, false, -1, unlockedTrackbar, onEveryTick));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,7 +38,7 @@ static bool returningToHiddenMain = false;
 static bool returningToSettings = false;
 static bool returningToPackage = false;
 static bool returningToSubPackage = false;
-static bool inMainMenu = false;
+//static bool inMainMenu = false; // moved to libtesla
 static bool inHiddenMode = false;
 static bool inSettingsMenu = false;
 static bool inSubSettingsMenu = false;
@@ -48,7 +48,7 @@ static bool inScriptMenu = false;
 static bool inSelectionMenu = false;
 //static bool currentMenuLoaded = true;
 static bool freshSpawn = true;
-//static bool refreshGui = false; (moved)
+//static bool refreshGui = false; //moved to libtesla
 static bool reloadMenu = false;
 static bool reloadMenu2 = false;
 static bool reloadMenu3 = false;
@@ -971,6 +971,7 @@ public:
                     simulatedSelect = false;
                 }
                 if (keys & KEY_A) {
+                    inMainMenu = false;
                     tsl::changeTo<SettingsMenu>(entryName, entryMode, overlayName, PRIORITY_STR);
                     selectedListItem.reset();
                     selectedListItem = listItemPtr;
@@ -2442,7 +2443,7 @@ public:
         
         if (refreshGui && !returningToPackage && !stillTouching) {
             refreshGui = false;
-            
+
             // Function to handle the transition and state resetting
             auto handleMenuTransition = [&] {
                 lastPackagePath = packagePath;
@@ -2705,7 +2706,8 @@ public:
      *
      * Initializes a new instance of the `MainMenu` class with the necessary parameters.
      */
-    MainMenu(const std::string& hiddenMenuMode = "", const std::string& sectionName = "") : hiddenMenuMode(hiddenMenuMode), dropdownSection(sectionName) {}
+    MainMenu(const std::string& hiddenMenuMode = "", const std::string& sectionName = "") : hiddenMenuMode(hiddenMenuMode), dropdownSection(sectionName) {
+    }
     /**
      * @brief Destroys the `MainMenu` instance.
      *
@@ -2729,8 +2731,10 @@ public:
             setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, IN_HIDDEN_OVERLAY_STR, FALSE_STR);
         }
 
-        if (!inHiddenMode)
+        if (!inHiddenMode && dropdownSection.empty())
             inMainMenu = true;
+        else
+            inMainMenu = false;
         
         tsl::hlp::ini::IniData settingsData, packageConfigData;
         std::string packagePath, pathReplace, pathReplaceOn, pathReplaceOff;
@@ -3279,7 +3283,7 @@ public:
                                     reloadMenu2 = true;
                                 }
                                 refreshGui = true;
-                                
+
                                 //tsl::changeTo<MainMenu>(hiddenMenuMode);
                                 return true;
                             } else if (keys & SETTINGS_KEY) {
@@ -3902,6 +3906,7 @@ public:
                 }
 
                 if ((keysHeld & SYSTEM_SETTINGS_KEY) && !stillTouching) {
+                    inMainMenu = false;
                     tsl::changeTo<UltrahandSettingsMenu>();
                     //if (menuMode != PACKAGES_STR) startInterpreterThread();
                     

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -73,6 +73,7 @@ static const std::string ALIGNMENT_PATTERN = ";alignment=";
 static const std::string GAP_PATTERN =";gap=";
 static const std::string OFFSET_PATTERN = ";offset=";
 static const std::string SPACING_PATTERN = ";spacing=";
+static const std::string COLOR_MODE_PATTERN = ";color_mode=";
 
 // Trackbar option patterns
 static const std::string MIN_VALUE_PATTERN = ";min_value=";
@@ -131,6 +132,7 @@ struct CommandOptions {
     size_t& tableEndGap;
     size_t& tableColumnOffset;
     size_t& tableSpacing;
+    std::string& tableColorMode;
     std::string& tableAlignment;
     s16& minValue;
     s16& maxValue;
@@ -215,6 +217,9 @@ void processCommands(CommandOptions& options, CommandData& data) {
                 continue;
             } else if (options.commandName.find(SPACING_PATTERN) == 0) {
                 options.tableSpacing = std::stoi(options.commandName.substr(SPACING_PATTERN.length()));
+                continue;
+            } else if (options.commandName.find(COLOR_MODE_PATTERN) == 0) {
+                options.tableColorMode = options.commandName.substr(COLOR_MODE_PATTERN.length());
                 continue;
             } else if (options.commandName.find(ALIGNMENT_PATTERN) == 0) {
                 options.tableAlignment = options.commandName.substr(ALIGNMENT_PATTERN.length());
@@ -1921,13 +1926,13 @@ public:
         
         bool hideTableBackground;
         size_t tableStartGap, tableEndGap, tableColumnOffset, tableSpacing;
-        std::string tableAlignment;
+        std::string tableColorMode, tableAlignment;
 
         // Pack variables into structs
         CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
                                   commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
                                   sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
-                                  tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableAlignment,
+                                  tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableColorMode, tableAlignment,
                                   minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
         
         CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
@@ -1947,6 +1952,7 @@ public:
             tableEndGap = 3;
             tableColumnOffset = 160;
             tableSpacing = 0;
+            tableColorMode = DEFAULT_STR;
             tableAlignment = RIGHT_STR;
             
             // Trackbar settings
@@ -2132,7 +2138,7 @@ public:
                 
                 if (!skipSection && !skipSystem) { // for skipping the drawing of sections
                     if (commandMode == TABLE_STR) {
-                        addTable(list, tableData, this->packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableAlignment, hideTableBackground);
+                        addTable(list, tableData, this->packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
                         continue;
                     } else if (commandMode == TRACKBAR_STR) {
                         list->addItem(new tsl::elm::TrackBar(optionName, this->packagePath, minValue, maxValue, units, interpretAndExecuteCommands, commands, option.first, false, false, -1, unlockedTrackbar, onEveryTick));
@@ -3391,7 +3397,7 @@ public:
 
                 bool hideTableBackground;
                 size_t tableStartGap, tableEndGap, tableColumnOffset, tableSpacing;
-                std::string tableAlignment;
+                std::string tableColorMode, tableAlignment;
                 
                 s16 minValue;
                 s16 maxValue;
@@ -3406,7 +3412,7 @@ public:
                 CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
                                           commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
                                           sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
-                                          tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableAlignment,
+                                          tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableColorMode, tableAlignment,
                                           minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
                 
                 CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
@@ -3425,6 +3431,7 @@ public:
                     tableEndGap = 3;
                     tableColumnOffset = 160;
                     tableSpacing = 0;
+                    tableColorMode = DEFAULT_STR;
                     tableAlignment = RIGHT_STR;
                     
                     minValue = 0;
@@ -3567,7 +3574,7 @@ public:
                     
                     if (!skipSection && !skipSystem) {
                         if (commandMode == TABLE_STR) {
-                            addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableAlignment, hideTableBackground);
+                            addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
                             continue;
                         } else if (commandMode == TRACKBAR_STR) {
                             list->addItem(new tsl::elm::TrackBar(optionName, packagePath, minValue, maxValue, units, interpretAndExecuteCommands, commands, option.first, false, false, -1, unlockedTrackbar, onEveryTick));

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -235,7 +235,8 @@ std::tuple<Result, std::string, std::string> getOverlayInfo(const std::string& f
 }
 
 void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::string>& sectionLines, const std::vector<std::string>& infoLines,
-    const size_t& columnOffset = 120, const size_t& startGap = 20, const size_t& endGap = 3, const size_t& newlineGap = 0, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false) {
+    const size_t& columnOffset = 120, const size_t& startGap = 20, const size_t& endGap = 3, const size_t& newlineGap = 0,
+    const std::string& tableColorMode = DEFAULT_STR, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false) {
 
     size_t lineHeight = 16;
     size_t fontSize = 16;
@@ -243,6 +244,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
 
     auto sectionTextColor = tsl::gfx::Renderer::a(tsl::sectionTextColor);
     auto infoTextColor = tsl::gfx::Renderer::a(tsl::infoTextColor);
+    auto warningTextColor = tsl::gfx::Renderer::a(tsl::warningTextColor);
 
     size_t totalHeight = lineHeight * sectionLines.size() + newlineGap * (sectionLines.size() - 1) + endGap;
 
@@ -278,8 +280,8 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
         }
 
         for (size_t i = 0; i < sectionLines.size(); ++i) {
-            renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, sectionTextColor);
-            renderer->drawString(infoLines[i].c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, infoTextColor);
+            renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, ((tableColorMode == "warning") ? warningTextColor : sectionTextColor));
+            renderer->drawString(infoLines[i].c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, ((tableColorMode == "warning") ? warningTextColor : infoTextColor));
         }
     }, hideTableBackground, endGap), totalHeight);
 }
@@ -290,7 +292,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
 void applyPlaceholderReplacement(std::vector<std::string>& cmd, std::string hexPath, std::string iniPath, std::string listString, std::string listPath, std::string jsonString, std::string jsonPath);
 
 void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std::string>>& tableData,
-    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false) {
+    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0, const std::string& tableColorMode=DEFAULT_STR, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false) {
 
     //std::string sectionString, infoString;
     std::vector<std::string> sectionLines, infoLines;
@@ -383,7 +385,7 @@ void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std
     // seperate sectionString and info string.  the sections will be on the left side of the "=", the info will be on the right side of the "=" within the string.  the end of an entry will be met with a newline (except for the very last entry). 
     // sectionString and infoString will each have equal newlines (denoting )
 
-    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableAlignment, hideTableBackground);
+    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
 }
 
 

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -236,7 +236,7 @@ std::tuple<Result, std::string, std::string> getOverlayInfo(const std::string& f
 
 void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::string>& sectionLines, const std::vector<std::string>& infoLines,
     const size_t& columnOffset = 120, const size_t& startGap = 20, const size_t& endGap = 3, const size_t& newlineGap = 0,
-    const std::string& tableColorMode = DEFAULT_STR, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false) {
+    const std::string& tableSectionTextColor = DEFAULT_STR, const std::string& tableInfoTextColor = DEFAULT_STR, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false) {
 
     size_t lineHeight = 16;
     size_t fontSize = 16;
@@ -244,7 +244,24 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
 
     auto sectionTextColor = tsl::gfx::Renderer::a(tsl::sectionTextColor);
     auto infoTextColor = tsl::gfx::Renderer::a(tsl::infoTextColor);
-    auto warningTextColor = tsl::gfx::Renderer::a(tsl::warningTextColor);
+    auto alternateSectionTextColor = tsl::gfx::Renderer::a(tsl::warningTextColor);
+    auto alternateInfoTextColor = tsl::gfx::Renderer::a(tsl::warningTextColor);
+
+    if (tableSectionTextColor != DEFAULT_STR) {
+        if (tableSectionTextColor == "warning") {
+            alternateSectionTextColor = tsl::warningTextColor;
+        } else {
+            alternateSectionTextColor = tsl::RGB888(tableSectionTextColor);
+        }
+    }
+
+    if (tableInfoTextColor != DEFAULT_STR) {
+        if (tableInfoTextColor == "warning") {
+            alternateInfoTextColor = tsl::warningTextColor;
+        } else {
+            alternateInfoTextColor = tsl::RGB888(tableInfoTextColor);
+        }
+    }
 
     size_t totalHeight = lineHeight * sectionLines.size() + newlineGap * (sectionLines.size() - 1) + endGap;
 
@@ -280,8 +297,8 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
         }
 
         for (size_t i = 0; i < sectionLines.size(); ++i) {
-            renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, ((tableColorMode == "warning") ? warningTextColor : sectionTextColor));
-            renderer->drawString(infoLines[i].c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, ((tableColorMode == "warning") ? warningTextColor : infoTextColor));
+            renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, renderer->a((tableSectionTextColor == DEFAULT_STR) ? sectionTextColor : alternateSectionTextColor));
+            renderer->drawString(infoLines[i].c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, renderer->a((tableInfoTextColor == DEFAULT_STR) ? infoTextColor : alternateInfoTextColor));
         }
     }, hideTableBackground, endGap), totalHeight);
 }
@@ -292,7 +309,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
 void applyPlaceholderReplacement(std::vector<std::string>& cmd, std::string hexPath, std::string iniPath, std::string listString, std::string listPath, std::string jsonString, std::string jsonPath);
 
 void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std::string>>& tableData,
-    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0, const std::string& tableColorMode=DEFAULT_STR, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false) {
+    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0, const std::string& tableSectionTextColor=DEFAULT_STR, const std::string& tableInfoTextColor=DEFAULT_STR, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false) {
 
     //std::string sectionString, infoString;
     std::vector<std::string> sectionLines, infoLines;
@@ -385,7 +402,7 @@ void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std
     // seperate sectionString and info string.  the sections will be on the left side of the "=", the info will be on the right side of the "=" within the string.  the end of an entry will be met with a newline (except for the very last entry). 
     // sectionString and infoString will each have equal newlines (denoting )
 
-    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableColorMode, tableAlignment, hideTableBackground);
+    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground);
 }
 
 


### PR DESCRIPTION
List of changes:
1. Optimizations to the `;on_every_tick=` implementation for track-bars.
    - Faster on every tick command execution.
2. New table option addition `;section_text_color=` and `;info_text_color=`.
    - Both section and info text color are optional parameters that can be set to `default` (normally `default` when unspecified), `warning` (new built-in theme color `warning_text_color`), or any specified RGB888 hex color string.
3. Forwarder package versions and title colors are now inherited from the layer 0 package (package.ini) if left unspecified within the forwarder package.
    - Users no longer need to specify forwarder package versions and colors on every forwarder package ini.
4. Bottom buttons and settings menu touch functions now utilize `click_color` and `click_alpha` for drawing highlights on the additional touch regions.
5. Various touch interaction bug fixes. (touching "OK" on top of a track-bar, bottom regions for touch adjusted to language text size, etc.)
6. Slight tweaks to pixel blender for drawn strings during hiding.