### PR TITLE
Development for v1.6.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= ppkantorski
-APP_VERSION	:= 1.6.6
+APP_VERSION	:= 1.6.7
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1885,7 +1885,7 @@ public:
                     if (it != packageConfigData.end()) {
                         auto& optionSection = it->second;
                         auto footerIt = optionSection.find(FOOTER_STR);
-                        if (footerIt != optionSection.end() && footerIt->second != NULL_STR) {
+                        if (footerIt != optionSection.end() && (footerIt->second.find(NULL_STR) == std::string::npos)) {
                             selectedListItem->setValue(footerIt->second);
                         }
                     }
@@ -2292,7 +2292,7 @@ public:
                                 listItem->setValue(footer, true);
                         }
                         
-                        if (footer == UNAVAILABLE_SELECTION || footer == NOT_AVAILABLE_STR || footer == NULL_STR)
+                        if (footer == UNAVAILABLE_SELECTION || footer == NOT_AVAILABLE_STR || (footer.find(NULL_STR) != std::string::npos))
                             listItem->setValue(UNAVAILABLE_SELECTION, true);
 
                         if (commandMode == FORWARDER_STR) {
@@ -2339,7 +2339,7 @@ public:
                                 }
 
                                 if ((keys & KEY_A)) {
-                                    if (footer != UNAVAILABLE_SELECTION && footer != NOT_AVAILABLE_STR && footer != NULL_STR) {
+                                    if (footer != UNAVAILABLE_SELECTION && footer != NOT_AVAILABLE_STR && (footer.find(NULL_STR) == std::string::npos)) {
                                         if (inPackageMenu)
                                             inPackageMenu = false;
                                         if (inSubPackageMenu)

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -616,6 +616,7 @@ bool isDangerousCombination(const std::string& patternPath) {
     static const std::vector<std::string> protectedFolders = {
         "sdmc:/Nintendo/",
         "sdmc:/emuMMC/",
+        "sdmc:/emuMMC/RAW1/",
         "sdmc:/atmosphere/",
         "sdmc:/bootloader/",
         "sdmc:/switch/",
@@ -624,7 +625,9 @@ bool isDangerousCombination(const std::string& patternPath) {
     };
     static const std::vector<std::string> ultraProtectedFolders = {
         "sdmc:/Nintendo/Contents/",
-        "sdmc:/emuMMC/Nintendo/Contents/"
+        "sdmc:/Nintendo/save/",
+        "sdmc:/emuMMC/RAW1/Nintendo/Contents/",
+        "sdmc:/emuMMC/RAW1/Nintendo/save/"
     };
     static const std::vector<std::string> dangerousCombinationPatterns = {
         "*",         // Deletes all files/directories in the current directory
@@ -649,14 +652,25 @@ bool isDangerousCombination(const std::string& patternPath) {
         }
         if (patternPath.find(folder) == 0) {
             std::string relativePath = patternPath.substr(folder.size());
+
+            // Check for dangerous patterns in the relative path
             for (const auto& pattern : dangerousPatterns) {
                 if (relativePath.find(pattern) != std::string::npos) {
                     return true; // Relative path contains a dangerous pattern
                 }
             }
-            for (const auto& pattern : dangerousCombinationPatterns) {
-                if (patternPath == folder + pattern) {
-                    return true; // Path is a protected folder combined with a dangerous pattern
+
+            // Check for dangerous combination patterns in the relative path
+            for (const auto& combination : dangerousCombinationPatterns) {
+                if (relativePath.find(combination) != std::string::npos) {
+                    return true; // Relative path contains a dangerous combination pattern
+                }
+            }
+
+            // Check for wildcard patterns that could affect ultra-protected folders
+            for (const auto& ultraFolder : ultraProtectedFolders) {
+                if (patternPath.find(ultraFolder.substr(folder.size())) == 0) {
+                    return true; // Path with wildcard could affect an ultra-protected folder
                 }
             }
         }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -349,7 +349,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
     list->addItem(new tsl::elm::TableDrawer([=](tsl::gfx::Renderer* renderer, s32 x, s32 y, s32 w, s32 h) mutable {
         for (size_t i = 0; i < infoLines.size(); ++i) {
             if (infoStringWidths[i] == 0.0f) {  // Calculate only if not already calculated
-                if (infoLines[i] != NULL_STR)
+                if (infoLines[i].find(NULL_STR) == std::string::npos)
                     infoStringWidths[i] = renderer->calculateStringWidth(infoLines[i], fontSize, false);
                 else
                     infoStringWidths[i] = renderer->calculateStringWidth(UNAVAILABLE_SELECTION, fontSize, false);
@@ -367,7 +367,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
         for (size_t i = 0; i < sectionLines.size(); ++i) {
             renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, renderer->a((tableSectionTextColor == DEFAULT_STR) ? sectionTextColor : alternateSectionTextColor));
             // Check if infoLines[i] is "null" and replace it with UNAVAILABLE_SELECTION if true
-            std::string infoText = (infoLines[i] == NULL_STR) ? UNAVAILABLE_SELECTION : infoLines[i];
+            std::string infoText = (infoLines[i].find(NULL_STR) == std::string::npos) ? UNAVAILABLE_SELECTION : infoLines[i];
             renderer->drawString(infoText.c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, renderer->a((tableInfoTextColor == DEFAULT_STR) ? infoTextColor : alternateInfoTextColor));
         }
     }, hideTableBackground, endGap), totalHeight);
@@ -548,7 +548,7 @@ void addPackageInfo(std::unique_ptr<tsl::elm::List>& list, auto& packageHeader, 
                 sectionLines.push_back(std::string(aboutHeaderLength, ' '));
         }
     };
-
+    
     // Adding package header info
     if (!packageHeader.title.empty()) {
         sectionLines.push_back(TITLE);
@@ -563,9 +563,10 @@ void addPackageInfo(std::unique_ptr<tsl::elm::List>& list, auto& packageHeader, 
     }
 
     if (!packageHeader.creator.empty()) {
-        sectionLines.push_back(CREATOR);
-        infoLines.push_back(packageHeader.creator);
+        //sectionLines.push_back(CREATOR);
+        //infoLines.push_back(packageHeader.creator);
         //numEntries++;
+        addWrappedText(CREATOR, packageHeader.creator);
     }
 
     if (!packageHeader.about.empty()) {

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -367,7 +367,7 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
         for (size_t i = 0; i < sectionLines.size(); ++i) {
             renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, renderer->a((tableSectionTextColor == DEFAULT_STR) ? sectionTextColor : alternateSectionTextColor));
             // Check if infoLines[i] is "null" and replace it with UNAVAILABLE_SELECTION if true
-            std::string infoText = (infoLines[i].find(NULL_STR) == std::string::npos) ? UNAVAILABLE_SELECTION : infoLines[i];
+            std::string infoText = (infoLines[i].find(NULL_STR) != std::string::npos) ? UNAVAILABLE_SELECTION : infoLines[i];
             renderer->drawString(infoText.c_str(), false, x + infoXOffsets[i], y + yOffsets[i], fontSize, renderer->a((tableInfoTextColor == DEFAULT_STR) ? infoTextColor : alternateInfoTextColor));
         }
     }, hideTableBackground, endGap), totalHeight);
@@ -548,7 +548,7 @@ void addPackageInfo(std::unique_ptr<tsl::elm::List>& list, auto& packageHeader, 
                 sectionLines.push_back(std::string(aboutHeaderLength, ' '));
         }
     };
-    
+
     // Adding package header info
     if (!packageHeader.title.empty()) {
         sectionLines.push_back(TITLE);


### PR DESCRIPTION
List of changes:
1. New optional command options for `copy`, `move`, and `delete` commands for file logging and bulk executions.

    a. File manipulation logging (outputs a text list for source file and destination file locations)
    - `copy <source_file_path> <destination_file_path> -log_src <src_output_txt_file_path> -log_dest <dest_output_txt_file_path>`
    - `move <source_file_path> <destination_file_path> -log_src <src_output_txt_file_path> -log_dest <dest_output_txt_file_path>`
    - `delete <source_file_path> -log_src <src_output_txt_file_path>`
    
    b. Bulk execution (utilizes text lists to perform transfer operations on all entries)
    - `copy -src <src_output_txt_file_path> -dest <dest_output_txt_file_path>`
    - `move -src <src_output_txt_file_path> -dest <dest_output_txt_file_path>`
    - `delete -src <src_output_txt_file_path>`
 
2. Improvements and fixes to `file_source` toggle functions.
3. Improved handling of `null` placeholder replacements.
4. Corrections to `isDangerousCombination` (the dangerous pattern combination detection function).
    - The following paths are now ultra-protected (unable to delete or move files from):
        - `sdmc:/Nintendo/Contents/`
        - `sdmc:/Nintendo/save/`
        - `sdmc:/emuMMC/RAW1/Nintendo/Contents/`
        - `sdmc:/emuMMC/RAW1/Nintendo/save/`
    - Slight improvements to dangerous pattern detection.
5. Updates to [Mod Alchemist](https://github.com/ppkantorski/Mod-Alchemist) (now v0.4.6, requires Ultrahand v1.6.7+).