### PR TITLE
Development for v1.6.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= ppkantorski
-APP_VERSION	:= 1.6.8
+APP_VERSION	:= 1.6.9
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4456,7 +4456,7 @@ namespace tsl {
                     }
                     
                     std::tie(width, height) = renderer->drawString(this->m_text.c_str(), false, 0, 0, 23, a(tsl::style::color::ColorTransparent));
-                    this->m_trunctuated = width > this->m_maxWidth+10;
+                    this->m_trunctuated = width > this->m_maxWidth+20;
                     
                     if (this->m_trunctuated) {
                         this->m_scrollText = this->m_text + "        ";
@@ -5844,7 +5844,7 @@ namespace tsl {
             renderer.endFrame();
         }
         
-        
+
 
         /**
          * @brief Called once per frame with the latest HID inputs

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4477,7 +4477,10 @@ namespace tsl {
                 
                 if (this->m_trunctuated) {
                     if (this->m_focused) {
-                        renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6, tsl::cfg::FramebufferHeight-73-97);
+                        if (this->m_value.length() > 0)
+                            renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6-4, tsl::cfg::FramebufferHeight-73-97);
+                        else
+                            renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6, tsl::cfg::FramebufferHeight-73-97);
                         renderer->drawString(this->m_scrollText.c_str(), false, this->getX() + 20 - this->m_scrollOffset, this->getY() + 45, 23, a(selectedTextColor));
                         renderer->disableScissoring();
                         //t = std::chrono::system_clock::now() - this->timeIn;

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4503,20 +4503,33 @@ namespace tsl {
                 
                 
                 // CUSTOM SECTION START (modification for submenu footer color)
+                //const std::string& value = this->m_value;
+                int xPosition = this->getX() + this->m_maxWidth + 45 - 1;
+                int yPosition = this->getY() + 45;
+                int fontSize = 20;
+                //bool isFaint = ;
+                //bool isFocused = this->m_focused;
+
+                // Determine text color
+                auto textColor = offTextColor;
                 if (this->m_value == DROPDOWN_SYMBOL || this->m_value == OPTION_SYMBOL) {
-                    if (this->m_focused)
-                        renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45-1, this->getY() + 45, 20, !useClickTextColor ? (this->m_faint ? offTextColor : selectedTextColor) : a(clickTextColor));
-                    else
-                        renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45-1, this->getY() + 45, 20, !useClickTextColor ? (this->m_faint ? offTextColor : defaultTextColor) : a(clickTextColor));
+                    textColor = this->m_focused
+                        ? (!useClickTextColor ? (this->m_faint ? offTextColor : selectedTextColor) : a(clickTextColor))
+                        : (!useClickTextColor ? (this->m_faint ? offTextColor : defaultTextColor) : a(clickTextColor));
                 } else if (runningInterpreter.load(std::memory_order_acquire) &&
-                    ((((this->m_value).find(DOWNLOAD_SYMBOL) != std::string::npos) || ((this->m_value).find(UNZIP_SYMBOL) != std::string::npos) || ((this->m_value).find(COPY_SYMBOL) != std::string::npos)) || this->m_value == INPROGRESS_SYMBOL)) {
-                    
-                    renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45-1, this->getY() + 45, 20, (this->m_faint ? offTextColor : a(inprogressTextColor)));
+                    (this->m_value.find(DOWNLOAD_SYMBOL) != std::string::npos ||
+                     this->m_value.find(UNZIP_SYMBOL) != std::string::npos ||
+                     this->m_value.find(COPY_SYMBOL) != std::string::npos ||
+                     this->m_value == INPROGRESS_SYMBOL)) {
+                    textColor = this->m_faint ? offTextColor : a(inprogressTextColor);
                 } else if (this->m_value == CROSSMARK_SYMBOL) {
-                    renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45-1, this->getY() + 45, 20, (this->m_faint ? offTextColor : a(invalidTextColor)));
+                    textColor = this->m_faint ? offTextColor : a(invalidTextColor);
                 } else {
-                    renderer->drawString(this->m_value.c_str(), false, this->getX() + this->m_maxWidth + 45-1, this->getY() + 45, 20, (this->m_faint ? offTextColor : a(onTextColor)));
+                    textColor = this->m_faint ? offTextColor : a(onTextColor);
                 }
+
+                // Draw the string with the determined text color
+                renderer->drawString(this->m_value.c_str(), false, xPosition, yPosition, fontSize, textColor);
                 // CUSTOM SECTION END 
             }
             

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -6580,7 +6580,12 @@ std::unordered_map<std::string, std::string> buttonCharMap = createButtonCharMap
 std::string convertComboToUnicode(const std::string& combo) {
     // Check if there is a '+' in the input string
     if (combo.find('+') == std::string::npos) {
-        // If no '+' is found, return the original string
+        // If no '+' is found, check if the entire combo is a single key that maps to Unicode
+        auto it = buttonCharMap.find(trim(combo));  // Trim the input in case of leading/trailing spaces
+        if (it != buttonCharMap.end()) {
+            return it->second;
+        }
+        // If no mapping is found, return the original string
         return combo;
     }
     

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4481,7 +4481,7 @@ namespace tsl {
                             renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6-4, tsl::cfg::FramebufferHeight-73-97);
                         else
                             renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6, tsl::cfg::FramebufferHeight-73-97);
-                        renderer->drawString(this->m_scrollText.c_str(), false, this->getX() + 20 - this->m_scrollOffset, this->getY() + 45, 23, a(selectedTextColor));
+                        renderer->drawString(this->m_scrollText.c_str(), false, this->getX() + 20-1 - this->m_scrollOffset, this->getY() + 45, 23, a(selectedTextColor));
                         renderer->disableScissoring();
                         //t = std::chrono::system_clock::now() - this->timeIn;
                         if (std::chrono::system_clock::now() - this->timeIn >= 2000ms) {
@@ -4498,7 +4498,7 @@ namespace tsl {
                     }
                 } else {
                     // Render the text with special character handling
-                    renderer->drawStringWithColoredSections(this->m_text, {STAR_SYMBOL+"  "}, this->getX() + 20, this->getY() + 45, 23,
+                    renderer->drawStringWithColoredSections(this->m_text, {STAR_SYMBOL+"  "}, this->getX() + 20-1, this->getY() + 45, 23,
                         a(this->m_focused ? (!useClickTextColor ? selectedTextColor : clickTextColor) : (!useClickTextColor ? defaultTextColor : clickTextColor)),
                         a(this->m_focused ? starColor : selectionStarColor)
                     );

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4497,7 +4497,7 @@ namespace tsl {
                             }
                         } // CUSTOM MODIFICATION END
                     } else {
-                        renderer->drawString(this->m_ellipsisText.c_str(), false, this->getX() + 20, this->getY() + 45, 23, a(!useClickTextColor ? defaultTextColor : clickTextColor));
+                        renderer->drawString(this->m_ellipsisText.c_str(), false, this->getX() + 20-1, this->getY() + 45, 23, a(!useClickTextColor ? defaultTextColor : clickTextColor));
                     }
                 } else {
                     // Render the text with special character handling

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -5844,6 +5844,7 @@ namespace tsl {
             renderer.endFrame();
         }
         
+        
 
         /**
          * @brief Called once per frame with the latest HID inputs

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -161,7 +161,7 @@ bool updateMenuCombos = false;
 #define touchInput &touchPos
 #define JoystickPosition HidAnalogStickState
 
-
+std::string convertComboToUnicode(const std::string& combo);
 
 // For improving the speed of hexing consecutively with the same file and asciiPattern.
 //static std::unordered_map<std::string, std::string> hexSumCache;
@@ -4447,6 +4447,9 @@ namespace tsl {
                     //renderer->drawRect(ELEMENT_BOUNDS(this), tsl::style::color::ColorClickAnimation);
                 }
                 
+                this->m_text = convertComboToUnicode(this->m_text);
+                this->m_value = convertComboToUnicode(this->m_value);
+
                 if (this->m_maxWidth == 0) {
                     if (this->m_value.length() > 0) {
                         std::tie(width, height) = renderer->drawString(this->m_value.c_str(), false, 0, 0, 20, a(tsl::style::color::ColorTransparent));
@@ -6562,6 +6565,50 @@ namespace tsl {
     }
 
 }
+
+std::unordered_map<std::string, std::string> createButtonCharMap() {
+    std::unordered_map<std::string, std::string> map;
+    for (const auto& keyInfo : tsl::impl::KEYS_INFO) {
+        map[keyInfo.name] = keyInfo.glyph;
+    }
+    return map;
+}
+
+std::unordered_map<std::string, std::string> buttonCharMap = createButtonCharMap();
+
+
+std::string convertComboToUnicode(const std::string& combo) {
+    // Check if there is a '+' in the input string
+    if (combo.find('+') == std::string::npos) {
+        // If no '+' is found, return the original string
+        return combo;
+    }
+    
+    std::istringstream iss(combo);
+    std::string token;
+    std::string unicodeCombo;
+    bool modified = false;
+
+    while (std::getline(iss, token, '+')) {
+        std::string trimmedToken = trim(token);
+        auto it = buttonCharMap.find(trimmedToken);
+
+        if (it != buttonCharMap.end()) {
+            unicodeCombo += it->second + "+";
+            modified = true;
+        } else {
+            unicodeCombo += trimmedToken + "+";
+        }
+    }
+
+    if (!unicodeCombo.empty()) {
+        unicodeCombo.pop_back();  // Remove the trailing '+'
+    }
+
+    // If no modification was made, return the original combo
+    return modified ? unicodeCombo : combo;
+}
+
 
 
 #ifdef TESLA_INIT_IMPL

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -4477,7 +4477,7 @@ namespace tsl {
                 
                 if (this->m_trunctuated) {
                     if (this->m_focused) {
-                        renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 10+6 -10, tsl::cfg::FramebufferHeight-73-97);
+                        renderer->enableScissoring(this->getX()+6, 97, this->m_maxWidth + 40 - 6, tsl::cfg::FramebufferHeight-73-97);
                         renderer->drawString(this->m_scrollText.c_str(), false, this->getX() + 20 - this->m_scrollOffset, this->getY() + 45, 23, a(selectedTextColor));
                         renderer->disableScissoring();
                         //t = std::chrono::system_clock::now() - this->timeIn;
@@ -5918,7 +5918,7 @@ namespace tsl {
             
 
             if (hasScrolled) {
-                bool singleArrowKeyPress = ((keysHeld & HidNpadButton_AnyUp) != 0) + ((keysHeld & HidNpadButton_AnyDown) != 0) + ((keysHeld & HidNpadButton_AnyLeft) != 0) + ((keysHeld & HidNpadButton_AnyRight) != 0) == 1;
+                bool singleArrowKeyPress = ((keysHeld & KEY_UP) != 0) + ((keysHeld & KEY_DOWN) != 0) + ((keysHeld & KEY_LEFT) != 0) + ((keysHeld & KEY_RIGHT) != 0) == 1;
                 
                 
                 if (singleArrowKeyPress) {
@@ -5931,7 +5931,7 @@ namespace tsl {
 
                 if (!touchDetected && !oldTouchDetected && !handled && currentFocus && !stillTouching && !runningInterpreter.load(std::memory_order_acquire)) {
                     static bool shouldShake = true;
-                    bool singleArrowKeyPress = ((keysHeld & HidNpadButton_AnyUp) != 0) + ((keysHeld & HidNpadButton_AnyDown) != 0) + ((keysHeld & HidNpadButton_AnyLeft) != 0) + ((keysHeld & HidNpadButton_AnyRight) != 0) == 1;
+                    bool singleArrowKeyPress = ((keysHeld & KEY_UP) != 0) + ((keysHeld & KEY_DOWN) != 0) + ((keysHeld & KEY_LEFT) != 0) + ((keysHeld & KEY_RIGHT) != 0) == 1;
                     
                     if (singleArrowKeyPress) {
                         
@@ -5951,6 +5951,8 @@ namespace tsl {
                                 currentGui->requestFocus(currentFocus->getParent(), FocusDirection::Right, shouldShake);
                             //shouldShake = currentGui->getFocusedElement() != currentFocus;
                         }
+                        if (keysHeld & ~KEY_DOWN & ~KEY_UP & ~KEY_LEFT & ~KEY_RIGHT & ALL_KEYS_MASK) // reset
+                            buttonPressTime = now;
                         
                         auto durationSincePress = std::chrono::duration_cast<std::chrono::milliseconds>(now - buttonPressTime);
                         auto durationSinceLastEvent = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastKeyEventTime);

--- a/lib/libultra/include/download_funcs.hpp
+++ b/lib/libultra/include/download_funcs.hpp
@@ -31,6 +31,9 @@
 size_t DOWNLOAD_BUFFER_SIZE = 4096*4;
 size_t UNZIP_BUFFER_SIZE = 4096*4;
 
+// Path to the CA certificate
+const std::string cacertPath = "sdmc:/config/ultrahand/cacert.pem";
+const std::string cacertURL = "https://curl.se/ca/cacert.pem";
 
 // Shared atomic flag to indicate whether to abort the download operation
 static std::atomic<bool> abortDownload(false);
@@ -102,12 +105,12 @@ void cleanupCurl() {
 // Your downloadFile function
 bool downloadFile(const std::string& url, const std::string& toDestination) {
     abortDownload.store(false);
-
+    
     if (url.find_first_of("{}") != std::string::npos) {
         logMessage("Invalid URL: " + url);
         return false;
     }
-
+    
     std::string destination = toDestination;
     if (destination.back() == '/') {
         createDirectory(destination);
@@ -121,21 +124,21 @@ bool downloadFile(const std::string& url, const std::string& toDestination) {
     } else {
         createDirectory(destination.substr(0, destination.find_last_of('/')));
     }
-
+    
     std::ofstream file(destination, std::ios::binary);
     if (!file.is_open()) {
         logMessage("Error opening file: " + destination);
         return false;
     }
-
+    
     std::unique_ptr<CURL, CurlDeleter> curl(curl_easy_init());
     if (!curl) {
         logMessage("Error initializing curl.");
         return false;
     }
-
+    
     downloadPercentage.store(0, std::memory_order_release);
-
+    
     curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, writeCallback);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &file);
@@ -145,24 +148,24 @@ bool downloadFile(const std::string& url, const std::string& toDestination) {
     curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, userAgent.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); // Enable HTTP/2
     curl_easy_setopt(curl.get(), CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // Force TLS 1.2
-
+    
     // Disable SSL verification for testing purposes
-    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
+    //curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
+    //curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
     
     curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl.get(), CURLOPT_BUFFERSIZE, DOWNLOAD_BUFFER_SIZE); // Increase buffer size
-
+    
     CURLcode result = curl_easy_perform(curl.get());
     file.close();
-
+    
     if (result != CURLE_OK) {
         logMessage("Error downloading file: " + std::string(curl_easy_strerror(result)));
         deleteFileOrDirectory(destination);
         downloadPercentage.store(-1, std::memory_order_release);
         return false;
     }
-
+    
     std::ifstream checkFile(destination);
     if (!checkFile || checkFile.peek() == std::ifstream::traits_type::eof()) {
         logMessage("Error downloading file: Empty file");
@@ -171,7 +174,7 @@ bool downloadFile(const std::string& url, const std::string& toDestination) {
         return false;
     }
     checkFile.close();
-
+    
     downloadPercentage.store(100, std::memory_order_release);
     logMessage("Download Complete!");
     return true;

--- a/lib/libultra/include/download_funcs.hpp
+++ b/lib/libultra/include/download_funcs.hpp
@@ -145,6 +145,11 @@ bool downloadFile(const std::string& url, const std::string& toDestination) {
     curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, userAgent.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS); // Enable HTTP/2
     curl_easy_setopt(curl.get(), CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // Force TLS 1.2
+
+    // Disable SSL verification for testing purposes
+    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
+    
     curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl.get(), CURLOPT_BUFFERSIZE, DOWNLOAD_BUFFER_SIZE); // Increase buffer size
 

--- a/lib/libultra/include/download_funcs.hpp
+++ b/lib/libultra/include/download_funcs.hpp
@@ -126,7 +126,7 @@ bool downloadFile(const std::string& url, const std::string& toDestination) {
     }
 
 
-    std::string tempFilePath = createHiddenFilePath(destination) + ".tmp";
+    std::string tempFilePath = DOWNLOADS_PATH + getFileName(destination) + ".tmp";
 
     std::ofstream file(tempFilePath, std::ios::binary);
     if (!file.is_open()) {

--- a/lib/libultra/include/json_funcs.hpp
+++ b/lib/libultra/include/json_funcs.hpp
@@ -109,3 +109,54 @@ inline const char* getStringFromJson(const json_t* root, const char* key) {
     }
 }
 
+
+/**
+ * @brief Loads a JSON file from the specified path and retrieves a string value for a given key.
+ *
+ * This function combines the functionality of loading a JSON file and retrieving a string value associated
+ * with a given key in a single step.
+ *
+ * @param filePath The path to the JSON file.
+ * @param key The key whose associated string value is to be retrieved.
+ * @return A string containing the value associated with the given key, or an empty string if the key is not found.
+ */
+std::string getStringFromJsonFile(const std::string& filePath, const std::string& key) {
+    // Load JSON from file
+    json_t* root = readJsonFromFile(filePath);
+    if (!root) {
+        logMessage("Failed to load JSON file from path: " + filePath);
+        return "";
+    }
+
+    // Log the entire JSON object for debugging
+    char* jsonString = json_dumps(root, JSON_INDENT(2));
+    if (jsonString) {
+        //logMessage("Loaded JSON: " + std::string(jsonString));
+        free(jsonString);
+    } else {
+        logMessage("Error dumping JSON to string.");
+    }
+
+    // Retrieve the string value associated with the key
+    json_t* jsonKey = json_object_get(root, key.c_str());
+    if (!jsonKey) {
+        logMessage("Key not found in JSON: " + key);
+        json_decref(root);
+        return "";
+    }
+
+    if (!json_is_string(jsonKey)) {
+        logMessage("Value for key '" + key + "' is not a string");
+        json_decref(root);
+        return "";
+    }
+
+    const char* value = json_string_value(jsonKey);
+
+    // Clean up JSON object
+    json_decref(root);
+    //logMessage("Value for key '" + key + "': " + std::string(value));
+
+    // Return the string value
+    return std::string(value);
+}

--- a/lib/libultra/include/json_funcs.hpp
+++ b/lib/libultra/include/json_funcs.hpp
@@ -128,35 +128,18 @@ std::string getStringFromJsonFile(const std::string& filePath, const std::string
         return "";
     }
 
-    // Log the entire JSON object for debugging
-    char* jsonString = json_dumps(root, JSON_INDENT(2));
-    if (jsonString) {
-        //logMessage("Loaded JSON: " + std::string(jsonString));
-        free(jsonString);
-    } else {
-        logMessage("Error dumping JSON to string.");
-    }
-
     // Retrieve the string value associated with the key
     json_t* jsonKey = json_object_get(root, key.c_str());
-    if (!jsonKey) {
-        logMessage("Key not found in JSON: " + key);
-        json_decref(root);
-        return "";
-    }
-
-    if (!json_is_string(jsonKey)) {
-        logMessage("Value for key '" + key + "' is not a string");
-        json_decref(root);
-        return "";
-    }
-
-    const char* value = json_string_value(jsonKey);
+    const char* value = json_is_string(jsonKey) ? json_string_value(jsonKey) : nullptr;
 
     // Clean up JSON object
     json_decref(root);
-    //logMessage("Value for key '" + key + "': " + std::string(value));
 
-    // Return the string value
-    return std::string(value);
+    // Check if the value was found and return it
+    if (value) {
+        return std::string(value);
+    } else {
+        logMessage("Key not found or not a string in JSON: " + key);
+        return "";
+    }
 }

--- a/lib/libultra/include/string_funcs.hpp
+++ b/lib/libultra/include/string_funcs.hpp
@@ -484,22 +484,7 @@ inline std::string splitString(const std::string& str, const std::string& delimi
     }
 }
 
-std::string createHiddenFilePath(const std::string& originalPath) {
-    // Find the position of the last '/'
-    size_t lastSlash = originalPath.find_last_of('/');
 
-    // Extract the directory and filename
-    std::string directory = (lastSlash == std::string::npos) ? "" : originalPath.substr(0, lastSlash);
-    std::string filename = (lastSlash == std::string::npos) ? originalPath : originalPath.substr(lastSlash + 1);
-
-    // Add '.' to the start of the filename to make it hidden
-    std::string hiddenFilename = "." + filename;
-
-    // Combine the directory with the hidden filename
-    std::string hiddenFilePath = directory.empty() ? hiddenFilename : directory + "/" + hiddenFilename;
-
-    return hiddenFilePath;
-}
 
 
 //std::string padToEqualLength(const std::string& str, size_t len) {

--- a/lib/libultra/include/string_funcs.hpp
+++ b/lib/libultra/include/string_funcs.hpp
@@ -64,11 +64,12 @@ inline std::string cleanDirectoryName(const std::string& name) {
 inline std::string trim(const std::string& str) {
     size_t first = str.find_first_not_of(" \t\n\r\f\v");
     if (first == std::string::npos)
-        return "";
+        return {};  // Use {} to avoid an extra constructor call
 
     size_t last = str.find_last_not_of(" \t\n\r\f\v");
     return str.substr(first, last - first + 1);
 }
+
 
 // Function to trim newline characters from the end of a string
 inline std::string trimNewline(const std::string &str) {
@@ -437,7 +438,7 @@ inline std::string cleanVersionLabel(const std::string& input) {
             }
         }
     }
-
+    
     return versionLabel;
 }
 
@@ -481,6 +482,23 @@ inline std::string splitString(const std::string& str, const std::string& delimi
     } else {
         return ""; // Return empty string if index is out of bounds
     }
+}
+
+std::string createHiddenFilePath(const std::string& originalPath) {
+    // Find the position of the last '/'
+    size_t lastSlash = originalPath.find_last_of('/');
+
+    // Extract the directory and filename
+    std::string directory = (lastSlash == std::string::npos) ? "" : originalPath.substr(0, lastSlash);
+    std::string filename = (lastSlash == std::string::npos) ? originalPath : originalPath.substr(lastSlash + 1);
+
+    // Add '.' to the start of the filename to make it hidden
+    std::string hiddenFilename = "." + filename;
+
+    // Combine the directory with the hidden filename
+    std::string hiddenFilePath = directory.empty() ? hiddenFilename : directory + "/" + hiddenFilename;
+
+    return hiddenFilePath;
 }
 
 

--- a/lib/libultra/include/ultra.hpp
+++ b/lib/libultra/include/ultra.hpp
@@ -44,6 +44,8 @@ const std::string OVERLAY_PATH = "sdmc:/switch/.overlays/";
 const std::string OVERLAYS_INI_FILEPATH = "sdmc:/config/ultrahand/overlays.ini";
 const std::string PACKAGES_INI_FILEPATH = "sdmc:/config/ultrahand/packages.ini";
 const std::string ULTRAHAND_REPO_URL = "https://github.com/ppkantorski/Ultrahand-Overlay/";
+const std::string INCLUDED_THEME_URL = "https://raw.githubusercontent.com/ppkantorski/Ultrahand-Overlay/main/themes/ultra.ini";
+const std::string LATEST_RELEASE_INFO_URL = "https://api.github.com/repos/ppkantorski/Ultrahand-Overlay/releases/latest";
 
 const std::string TESLA_COMBO_STR = "L+DDOWN+RS";
 const std::string ULTRAHAND_COMBO_STR = "ZL+ZR+DDOWN";

--- a/lib/libultra/include/ultra.hpp
+++ b/lib/libultra/include/ultra.hpp
@@ -44,7 +44,7 @@ const std::string OVERLAY_PATH = "sdmc:/switch/.overlays/";
 const std::string OVERLAYS_INI_FILEPATH = "sdmc:/config/ultrahand/overlays.ini";
 const std::string PACKAGES_INI_FILEPATH = "sdmc:/config/ultrahand/packages.ini";
 const std::string ULTRAHAND_REPO_URL = "https://github.com/ppkantorski/Ultrahand-Overlay/";
-const std::string INCLUDED_THEME_URL = "https://raw.githubusercontent.com/ppkantorski/Ultrahand-Overlay/main/themes/ultra.ini";
+const std::string INCLUDED_THEME_FOLDER_URL = "https://raw.githubusercontent.com/ppkantorski/Ultrahand-Overlay/main/themes/";
 const std::string LATEST_RELEASE_INFO_URL = "https://api.github.com/repos/ppkantorski/Ultrahand-Overlay/releases/latest";
 
 const std::string TESLA_COMBO_STR = "L+DDOWN+RS";

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -2583,11 +2583,16 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                                 simulatedSelectComplete = true;
                                 return true;
                             } else if (keys & SCRIPT_KEY) {
+                                bool isFromMainMenu = (packagePath == PACKAGE_PATH);
+                                //if (inMainMenu) {
+                                //    isFromMainMenu = true;
+                                //    inMainMenu = false;
+                                //}
                                 if (inPackageMenu)
                                     inPackageMenu = false;
                                 if (inSubPackageMenu)
                                     inSubPackageMenu = false;
-                                tsl::changeTo<ScriptOverlay>(packagePath, keyName, false, packageName);
+                                tsl::changeTo<ScriptOverlay>(packagePath, keyName, isFromMainMenu, packageName);
                                 return true;
                             }
                             return false;
@@ -2637,11 +2642,16 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                                 lastSelectedListItem->triggerClickAnimation();
                                 return true;
                             }  else if (keys & SCRIPT_KEY) {
+                                bool isFromMainMenu = (packagePath == PACKAGE_PATH);
+                                //if (inMainMenu) {
+                                //    isFromMainMenu = true;
+                                //    inMainMenu = false;
+                                //}
                                 if (inPackageMenu)
                                     inPackageMenu = false;
                                 if (inSubPackageMenu)
                                     inSubPackageMenu = false;
-                                tsl::changeTo<ScriptOverlay>(packagePath, keyName, false, packageName);
+                                tsl::changeTo<ScriptOverlay>(packagePath, keyName, isFromMainMenu, packageName);
                                 return true;
                             }
                             return false;
@@ -3829,7 +3839,7 @@ public:
             
             if (!inHiddenMode) {
                 packagePath = PACKAGE_PATH;
-                std::string packageName = getNameFromPath(PACKAGE_PATH);
+                std::string packageName = "package.ini";
                 std::string pageLeftName = "";
                 std::string pageRightName = "";
                 std::string currentPage = "left";

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -68,7 +68,7 @@ static const std::string SYSTEM_PATTERN = ";system=";
 
 // Table option patterns
 static const std::string BACKGROUND_PATTERN = ";background="; // true or false
-static const std::string HEADER_INDENT_PATTERN = ";header_indent=";
+static const std::string HEADER_INDENT_PATTERN = ";header_indent="; // true or false
 //static const std::string HEADER_PATTERN = ";header=";
 static const std::string ALIGNMENT_PATTERN = ";alignment=";
 static const std::string GAP_PATTERN =";gap=";
@@ -473,8 +473,9 @@ private:
 
     void handleSelection(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::string>& items, const std::string& defaultItem, const std::string& iniKey, const std::string& targetMenu) {
         for (const auto& item : items) {
-            auto mappedItem = convertComboToUnicode(item);
-            if (mappedItem.empty()) mappedItem = item;
+            //auto mappedItem = convertComboToUnicode(item); // moved to ListItem class in libTesla
+            //if (mappedItem.empty()) mappedItem = item;
+            auto mappedItem = item;
     
             auto listItem = std::make_unique<tsl::elm::ListItem>(mappedItem);
             if (item == defaultItem) {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -464,14 +464,17 @@ private:
 
                 if (targetMenu == "softwareUpdateMenu") {
                     executeCommands({
-                        {"try:"},
                         {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH + "latest_release.json"}
                     });
                 } else if (targetMenu == "themeMenu") {
                     if (!isFileOrDirectory(THEMES_PATH+"ultra.ini")) {
                         executeCommands({
-                            {"try:"},
-                            {"download", INCLUDED_THEME_URL, THEMES_PATH}
+                            {"download", INCLUDED_THEME_FOLDER_URL+"ultra.ini", THEMES_PATH}
+                        });
+                    }
+                    if (!isFileOrDirectory(THEMES_PATH+"classic.ini")) {
+                        executeCommands({
+                            {"download", INCLUDED_THEME_FOLDER_URL+"classic.ini", THEMES_PATH}
                         });
                     }
                 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -2183,7 +2183,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                         }
                         commandFooter = parseValueFromIniSection(packageConfigIniPath, optionName, FOOTER_STR);
                         // override loading of the command footer
-                        if (!commandFooter.empty()){
+                        if (!commandFooter.empty() && commandFooter != NULL_STR){
                             footer = commandFooter;
                             listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)));
                             listItem->setValue(footer);
@@ -2449,7 +2449,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             }
 
             // override loading of the command footer
-            if (!commandFooter.empty())
+            if (!commandFooter.empty() && commandFooter != NULL_STR)
                 footer = commandFooter;
 
             skipSystem = false;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -662,12 +662,13 @@ public:
                 index++;
             }
         } else if (dropdownSelection == "softwareUpdateMenu") {
-            std::string versionLabel = trim(cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name")));
+            std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name"));
             if (!versionLabel.empty() && versionLabel != "0")
                 setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version", versionLabel);
-            
-            if (versionLabel.empty())
+            else {
                 versionLabel = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version");
+            }
+            deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
 
             //versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -68,6 +68,7 @@ static const std::string SYSTEM_PATTERN = ";system=";
 
 // Table option patterns
 static const std::string BACKGROUND_PATTERN = ";background="; // true or false
+static const std::string HEADER_INDENT_PATTERN = ";header_indent=";
 //static const std::string HEADER_PATTERN = ";header=";
 static const std::string ALIGNMENT_PATTERN = ";alignment=";
 static const std::string GAP_PATTERN =";gap=";
@@ -111,188 +112,188 @@ const static auto SETTINGS_KEY = KEY_Y;
 const static auto STAR_KEY = KEY_X;
 
 
-struct CommandOptions {
-    bool& inEristaSection;
-    bool& inMarikoSection;
-    bool& usingErista;
-    bool& usingMariko;
-    std::string& commandName;
-    std::string& commandSystem;
-    std::string& commandMode;
-    std::string& commandGrouping;
-    std::string& currentSection;
-    std::string& pathPattern;
-    std::string& sourceType;
-    std::string& pathPatternOn;
-    std::string& sourceTypeOn;
-    std::string& pathPatternOff;
-    std::string& sourceTypeOff;
-    std::string& defaultToggleState;
-    bool& hideTableBackground;
-    size_t& tableStartGap;
-    size_t& tableEndGap;
-    size_t& tableColumnOffset;
-    size_t& tableSpacing;
-    std::string& tableSectionTextColor;
-    std::string& tableInfoTextColor;
-    std::string& tableAlignment;
-    s16& minValue;
-    s16& maxValue;
-    std::string& units;
-    size_t& steps;
-    bool& unlockedTrackbar;
-    bool& onEveryTick;
-    std::string& packageSource;
-    std::string& packagePath;
-};
+//struct CommandOptions {
+//    bool& inEristaSection;
+//    bool& inMarikoSection;
+//    bool& usingErista;
+//    bool& usingMariko;
+//    std::string& commandName;
+//    std::string& commandSystem;
+//    std::string& commandMode;
+//    std::string& commandGrouping;
+//    std::string& currentSection;
+//    std::string& pathPattern;
+//    std::string& sourceType;
+//    std::string& pathPatternOn;
+//    std::string& sourceTypeOn;
+//    std::string& pathPatternOff;
+//    std::string& sourceTypeOff;
+//    std::string& defaultToggleState;
+//    bool& hideTableBackground;
+//    size_t& tableStartGap;
+//    size_t& tableEndGap;
+//    size_t& tableColumnOffset;
+//    size_t& tableSpacing;
+//    std::string& tableSectionTextColor;
+//    std::string& tableInfoTextColor;
+//    std::string& tableAlignment;
+//    s16& minValue;
+//    s16& maxValue;
+//    std::string& units;
+//    size_t& steps;
+//    bool& unlockedTrackbar;
+//    bool& onEveryTick;
+//    std::string& packageSource;
+//    std::string& packagePath;
+//};
+//
+//struct CommandData {
+//    std::vector<std::vector<std::string>>& commands;
+//    std::vector<std::vector<std::string>>& commandsOn;
+//    std::vector<std::vector<std::string>>& commandsOff;
+//    std::vector<std::vector<std::string>>& tableData;
+//};
 
-struct CommandData {
-    std::vector<std::vector<std::string>>& commands;
-    std::vector<std::vector<std::string>>& commandsOn;
-    std::vector<std::vector<std::string>>& commandsOff;
-    std::vector<std::vector<std::string>>& tableData;
-};
 
 
-
-void processCommands(CommandOptions& options, CommandData& data) {
-    options.inEristaSection = false;
-    options.inMarikoSection = false;
-    size_t delimiterPos;
-
-    // Remove all empty command strings
-    data.commands.erase(std::remove_if(data.commands.begin(), data.commands.end(),
-        [](const std::vector<std::string>& vec) {
-            return vec.empty();
-        }),
-        data.commands.end());
-
-    // Initial processing of commands
-    for (const auto& cmd : data.commands) {
-        options.commandName = cmd[0];
-
-        std::string commandNameLower = stringToLowercase(options.commandName);
-        if (commandNameLower == "erista:") {
-            options.inEristaSection = true;
-            options.inMarikoSection = false;
-            continue;
-        } else if (commandNameLower == "mariko:") {
-            options.inEristaSection = false;
-            options.inMarikoSection = true;
-            continue;
-        }
-
-        if ((options.inEristaSection && !options.inMarikoSection && options.usingErista) || 
-            (!options.inEristaSection && options.inMarikoSection && options.usingMariko) || 
-            (!options.inEristaSection && !options.inMarikoSection)) {
-
-            if (options.commandName.find(SYSTEM_PATTERN) == 0) {
-                options.commandSystem = options.commandName.substr(SYSTEM_PATTERN.length());
-                if (std::find(commandSystems.begin(), commandSystems.end(), options.commandSystem) == commandSystems.end())
-                    options.commandSystem = commandSystems[0];
-                continue;
-            } else if (options.commandName.find(MODE_PATTERN) == 0) {
-                options.commandMode = options.commandName.substr(MODE_PATTERN.length());
-                if (options.commandMode.find(TOGGLE_STR) != std::string::npos) {
-                    delimiterPos = options.commandMode.find('?');
-                    if (delimiterPos != std::string::npos) {
-                        options.defaultToggleState = options.commandMode.substr(delimiterPos + 1);
-                    }
-                    options.commandMode = TOGGLE_STR;
-                } else if (std::find(commandModes.begin(), commandModes.end(), options.commandMode) == commandModes.end()) {
-                    options.commandMode = commandModes[0];
-                }
-                continue;
-            } else if (options.commandName.find(GROUPING_PATTERN) == 0) {
-                options.commandGrouping = options.commandName.substr(GROUPING_PATTERN.length());
-                if (std::find(commandGroupings.begin(), commandGroupings.end(), options.commandGrouping) == commandGroupings.end())
-                    options.commandGrouping = commandGroupings[0];
-                continue;
-            } else if (options.commandName.find(BACKGROUND_PATTERN) == 0) {
-                options.hideTableBackground = (options.commandName.substr(BACKGROUND_PATTERN.length()) == FALSE_STR);
-                continue;
-            } else if (options.commandName.find(GAP_PATTERN) == 0) {
-                options.tableEndGap = std::stoi(options.commandName.substr(GAP_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(OFFSET_PATTERN) == 0) {
-                options.tableColumnOffset = std::stoi(options.commandName.substr(OFFSET_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(SPACING_PATTERN) == 0) {
-                options.tableSpacing = std::stoi(options.commandName.substr(SPACING_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(SECTION_TEXT_COLOR_PATTERN) == 0) {
-                options.tableSectionTextColor = options.commandName.substr(SECTION_TEXT_COLOR_PATTERN.length());
-                continue;
-            } else if (options.commandName.find(INFO_TEXT_COLOR_PATTERN) == 0) {
-                options.tableInfoTextColor = options.commandName.substr(INFO_TEXT_COLOR_PATTERN.length());
-                continue;
-            } else if (options.commandName.find(ALIGNMENT_PATTERN) == 0) {
-                options.tableAlignment = options.commandName.substr(ALIGNMENT_PATTERN.length());
-                continue;
-
-            } else if (options.commandName.find(MIN_VALUE_PATTERN) == 0) {
-                options.minValue = std::stoi(options.commandName.substr(MIN_VALUE_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(MAX_VALUE_PATTERN) == 0) {
-                options.maxValue = std::stoi(options.commandName.substr(MAX_VALUE_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(UNITS_PATTERN) == 0) {
-                options.units = removeQuotes(options.commandName.substr(UNITS_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(STEPS_PATTERN) == 0) {
-                options.steps = std::stoi(options.commandName.substr(STEPS_PATTERN.length()));
-                continue;
-            } else if (options.commandName.find(UNLOCKED_PATTERN) == 0) {
-                options.unlockedTrackbar = (options.commandName.substr(UNLOCKED_PATTERN.length()) == TRUE_STR);
-                continue;
-            } else if (options.commandName.find(ON_EVERY_TICK_PATTERN) == 0) {
-                options.onEveryTick = (options.commandName.substr(ON_EVERY_TICK_PATTERN.length()) == TRUE_STR);
-                continue;
-            } else if (options.commandName.find(";") == 0) {
-                continue;
-            }
-
-            if (options.commandMode == TOGGLE_STR) {
-                if (options.commandName.find("on:") == 0)
-                    options.currentSection = ON_STR;
-                else if (options.commandName.find("off:") == 0)
-                    options.currentSection = OFF_STR;
-
-                if (options.currentSection == GLOBAL_STR) {
-                    data.commandsOn.push_back(cmd);
-                    data.commandsOff.push_back(cmd);
-                } else if (options.currentSection == ON_STR) {
-                    data.commandsOn.push_back(cmd);
-                } else if (options.currentSection == OFF_STR) {
-                    data.commandsOff.push_back(cmd);
-                }
-            } else if (options.commandMode == TABLE_STR) {
-                data.tableData.push_back(cmd);
-                continue;
-            } else if (options.commandMode == TRACKBAR_STR || options.commandMode == STEP_TRACKBAR_STR || options.commandMode == NAMED_STEP_TRACKBAR_STR) {
-                //data.commands.push_back(cmd);
-                continue;
-            }
-
-            if (cmd.size() > 1) {
-                if (options.commandName == "file_source") {
-                    if (options.currentSection == GLOBAL_STR) {
-                        options.pathPattern = preprocessPath(cmd[1], options.packagePath);
-                        options.sourceType = FILE_STR;
-                    } else if (options.currentSection == ON_STR) {
-                        options.pathPatternOn = preprocessPath(cmd[1], options.packagePath);
-                        options.sourceTypeOn = FILE_STR;
-                    } else if (options.currentSection == OFF_STR) {
-                        options.pathPatternOff = preprocessPath(cmd[1], options.packagePath);
-                        options.sourceTypeOff = FILE_STR;
-                    }
-                } else if (options.commandName == "package_source") {
-                    options.packageSource = preprocessPath(cmd[1], options.packagePath);
-                }
-            }
-        }
-    }
-}
+//void processCommands(CommandOptions& options, CommandData& data) {
+//    options.inEristaSection = false;
+//    options.inMarikoSection = false;
+//    size_t delimiterPos;
+//
+//    // Remove all empty command strings
+//    data.commands.erase(std::remove_if(data.commands.begin(), data.commands.end(),
+//        [](const std::vector<std::string>& vec) {
+//            return vec.empty();
+//        }),
+//        data.commands.end());
+//
+//    // Initial processing of commands
+//    for (const auto& cmd : data.commands) {
+//        options.commandName = cmd[0];
+//
+//        std::string commandNameLower = stringToLowercase(options.commandName);
+//        if (commandNameLower == "erista:") {
+//            options.inEristaSection = true;
+//            options.inMarikoSection = false;
+//            continue;
+//        } else if (commandNameLower == "mariko:") {
+//            options.inEristaSection = false;
+//            options.inMarikoSection = true;
+//            continue;
+//        }
+//
+//        if ((options.inEristaSection && !options.inMarikoSection && options.usingErista) || 
+//            (!options.inEristaSection && options.inMarikoSection && options.usingMariko) || 
+//            (!options.inEristaSection && !options.inMarikoSection)) {
+//
+//            if (options.commandName.find(SYSTEM_PATTERN) == 0) {
+//                options.commandSystem = options.commandName.substr(SYSTEM_PATTERN.length());
+//                if (std::find(commandSystems.begin(), commandSystems.end(), options.commandSystem) == commandSystems.end())
+//                    options.commandSystem = commandSystems[0];
+//                continue;
+//            } else if (options.commandName.find(MODE_PATTERN) == 0) {
+//                options.commandMode = options.commandName.substr(MODE_PATTERN.length());
+//                if (options.commandMode.find(TOGGLE_STR) != std::string::npos) {
+//                    delimiterPos = options.commandMode.find('?');
+//                    if (delimiterPos != std::string::npos) {
+//                        options.defaultToggleState = options.commandMode.substr(delimiterPos + 1);
+//                    }
+//                    options.commandMode = TOGGLE_STR;
+//                } else if (std::find(commandModes.begin(), commandModes.end(), options.commandMode) == commandModes.end()) {
+//                    options.commandMode = commandModes[0];
+//                }
+//                continue;
+//            } else if (options.commandName.find(GROUPING_PATTERN) == 0) {
+//                options.commandGrouping = options.commandName.substr(GROUPING_PATTERN.length());
+//                if (std::find(commandGroupings.begin(), commandGroupings.end(), options.commandGrouping) == commandGroupings.end())
+//                    options.commandGrouping = commandGroupings[0];
+//                continue;
+//            } else if (options.commandName.find(BACKGROUND_PATTERN) == 0) {
+//                options.hideTableBackground = (options.commandName.substr(BACKGROUND_PATTERN.length()) == FALSE_STR);
+//                continue;
+//            } else if (options.commandName.find(GAP_PATTERN) == 0) {
+//                options.tableEndGap = std::stoi(options.commandName.substr(GAP_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(OFFSET_PATTERN) == 0) {
+//                options.tableColumnOffset = std::stoi(options.commandName.substr(OFFSET_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(SPACING_PATTERN) == 0) {
+//                options.tableSpacing = std::stoi(options.commandName.substr(SPACING_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(SECTION_TEXT_COLOR_PATTERN) == 0) {
+//                options.tableSectionTextColor = options.commandName.substr(SECTION_TEXT_COLOR_PATTERN.length());
+//                continue;
+//            } else if (options.commandName.find(INFO_TEXT_COLOR_PATTERN) == 0) {
+//                options.tableInfoTextColor = options.commandName.substr(INFO_TEXT_COLOR_PATTERN.length());
+//                continue;
+//            } else if (options.commandName.find(ALIGNMENT_PATTERN) == 0) {
+//                options.tableAlignment = options.commandName.substr(ALIGNMENT_PATTERN.length());
+//                continue;
+//
+//            } else if (options.commandName.find(MIN_VALUE_PATTERN) == 0) {
+//                options.minValue = std::stoi(options.commandName.substr(MIN_VALUE_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(MAX_VALUE_PATTERN) == 0) {
+//                options.maxValue = std::stoi(options.commandName.substr(MAX_VALUE_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(UNITS_PATTERN) == 0) {
+//                options.units = removeQuotes(options.commandName.substr(UNITS_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(STEPS_PATTERN) == 0) {
+//                options.steps = std::stoi(options.commandName.substr(STEPS_PATTERN.length()));
+//                continue;
+//            } else if (options.commandName.find(UNLOCKED_PATTERN) == 0) {
+//                options.unlockedTrackbar = (options.commandName.substr(UNLOCKED_PATTERN.length()) == TRUE_STR);
+//                continue;
+//            } else if (options.commandName.find(ON_EVERY_TICK_PATTERN) == 0) {
+//                options.onEveryTick = (options.commandName.substr(ON_EVERY_TICK_PATTERN.length()) == TRUE_STR);
+//                continue;
+//            } else if (options.commandName.find(";") == 0) {
+//                continue;
+//            }
+//
+//            if (options.commandMode == TOGGLE_STR) {
+//                if (options.commandName.find("on:") == 0)
+//                    options.currentSection = ON_STR;
+//                else if (options.commandName.find("off:") == 0)
+//                    options.currentSection = OFF_STR;
+//
+//                if (options.currentSection == GLOBAL_STR) {
+//                    data.commandsOn.push_back(cmd);
+//                    data.commandsOff.push_back(cmd);
+//                } else if (options.currentSection == ON_STR) {
+//                    data.commandsOn.push_back(cmd);
+//                } else if (options.currentSection == OFF_STR) {
+//                    data.commandsOff.push_back(cmd);
+//                }
+//            } else if (options.commandMode == TABLE_STR) {
+//                data.tableData.push_back(cmd);
+//                continue;
+//            } else if (options.commandMode == TRACKBAR_STR || options.commandMode == STEP_TRACKBAR_STR || options.commandMode == NAMED_STEP_TRACKBAR_STR) {
+//                //data.commands.push_back(cmd);
+//                continue;
+//            }
+//
+//            if (cmd.size() > 1) {
+//                if (options.commandName == "file_source") {
+//                    if (options.currentSection == GLOBAL_STR) {
+//                        options.pathPattern = preprocessPath(cmd[1], options.packagePath);
+//                        options.sourceType = FILE_STR;
+//                    } else if (options.currentSection == ON_STR) {
+//                        options.pathPatternOn = preprocessPath(cmd[1], options.packagePath);
+//                        options.sourceTypeOn = FILE_STR;
+//                    } else if (options.currentSection == OFF_STR) {
+//                        options.pathPatternOff = preprocessPath(cmd[1], options.packagePath);
+//                        options.sourceTypeOff = FILE_STR;
+//                    }
+//                } else if (options.commandName == "package_source") {
+//                    options.packageSource = preprocessPath(cmd[1], options.packagePath);
+//                }
+//            }
+//        }
+//    }
+//}
 
 
 
@@ -2051,17 +2052,17 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
     bool inEristaSection;
     bool inMarikoSection;
     
-    bool hideTableBackground;
+    bool hideTableBackground, useHeaderIndent;
     size_t tableStartGap, tableEndGap, tableColumnOffset, tableSpacing;
     std::string tableSectionTextColor, tableInfoTextColor, tableAlignment;
     // Pack variables into structs
-    CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
-                              commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
-                              sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
-                              tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment,
-                              minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
-    
-    CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
+    //CommandOptions cmdOptions = {inEristaSection, inMarikoSection, usingErista, usingMariko, commandName, commandSystem,
+    //                          commandMode, commandGrouping, currentSection, pathPattern, sourceType, pathPatternOn,
+    //                          sourceTypeOn, pathPatternOff, sourceTypeOff, defaultToggleState, hideTableBackground,
+    //                          tableStartGap, tableEndGap, tableColumnOffset, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment,
+    //                          minValue, maxValue, units, steps, unlockedTrackbar, onEveryTick, packageSource, packagePath};
+    //
+    //CommandData cmdData = {commands, commandsOn, commandsOff, tableData};
     
     for (size_t i = 0; i < options.size(); ++i) {
         auto& option = options[i];
@@ -2073,6 +2074,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
         useSelection = false;
         // Table settings
         hideTableBackground = false;
+        useHeaderIndent = false;
         tableStartGap = 20;
         tableEndGap = 3;
         tableColumnOffset = 160;
@@ -2221,7 +2223,149 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             }
             
             // Call the function
-            processCommands(cmdOptions, cmdData);
+            //processCommands(cmdOptions, cmdData);
+
+
+            inEristaSection = false;
+            inMarikoSection = false;
+            size_t delimiterPos;
+            
+            // Remove all empty command strings
+            commands.erase(std::remove_if(commands.begin(), commands.end(),
+                [](const std::vector<std::string>& vec) {
+                    return vec.empty();
+                }),
+                commands.end());
+        
+            // Initial processing of commands
+            for (const auto& cmd : commands) {
+                commandName = cmd[0];
+        
+                std::string commandNameLower = stringToLowercase(commandName);
+                if (commandNameLower == "erista:") {
+                    inEristaSection = true;
+                    inMarikoSection = false;
+                    continue;
+                } else if (commandNameLower == "mariko:") {
+                    inEristaSection = false;
+                    inMarikoSection = true;
+                    continue;
+                }
+        
+                if ((inEristaSection && !inMarikoSection && usingErista) || 
+                    (!inEristaSection && inMarikoSection && usingMariko) || 
+                    (!inEristaSection && !inMarikoSection)) {
+        
+                    if (commandName.find(SYSTEM_PATTERN) == 0) {
+                        commandSystem = commandName.substr(SYSTEM_PATTERN.length());
+                        if (std::find(commandSystems.begin(), commandSystems.end(), commandSystem) == commandSystems.end())
+                            commandSystem = commandSystems[0];
+                        continue;
+                    } else if (commandName.find(MODE_PATTERN) == 0) {
+                        commandMode = commandName.substr(MODE_PATTERN.length());
+                        if (commandMode.find(TOGGLE_STR) != std::string::npos) {
+                            delimiterPos = commandMode.find('?');
+                            if (delimiterPos != std::string::npos) {
+                                defaultToggleState = commandMode.substr(delimiterPos + 1);
+                            }
+                            commandMode = TOGGLE_STR;
+                        } else if (std::find(commandModes.begin(), commandModes.end(), commandMode) == commandModes.end()) {
+                            commandMode = commandModes[0];
+                        }
+                        continue;
+                    } else if (commandName.find(GROUPING_PATTERN) == 0) {
+                        commandGrouping = commandName.substr(GROUPING_PATTERN.length());
+                        if (std::find(commandGroupings.begin(), commandGroupings.end(), commandGrouping) == commandGroupings.end())
+                            commandGrouping = commandGroupings[0];
+                        continue;
+                    } else if (commandName.find(BACKGROUND_PATTERN) == 0) {
+                        hideTableBackground = (commandName.substr(BACKGROUND_PATTERN.length()) == FALSE_STR);
+                        continue;
+                    } else if (commandName.find(HEADER_INDENT_PATTERN) == 0) {
+                        useHeaderIndent = (commandName.substr(HEADER_INDENT_PATTERN.length()) == TRUE_STR);
+                        continue;
+                    } else if (commandName.find(GAP_PATTERN) == 0) {
+                        tableEndGap = std::stoi(commandName.substr(GAP_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(OFFSET_PATTERN) == 0) {
+                        tableColumnOffset = std::stoi(commandName.substr(OFFSET_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(SPACING_PATTERN) == 0) {
+                        tableSpacing = std::stoi(commandName.substr(SPACING_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(SECTION_TEXT_COLOR_PATTERN) == 0) {
+                        tableSectionTextColor = commandName.substr(SECTION_TEXT_COLOR_PATTERN.length());
+                        continue;
+                    } else if (commandName.find(INFO_TEXT_COLOR_PATTERN) == 0) {
+                        tableInfoTextColor = commandName.substr(INFO_TEXT_COLOR_PATTERN.length());
+                        continue;
+                    } else if (commandName.find(ALIGNMENT_PATTERN) == 0) {
+                        tableAlignment = commandName.substr(ALIGNMENT_PATTERN.length());
+                        continue;
+        
+                    } else if (commandName.find(MIN_VALUE_PATTERN) == 0) {
+                        minValue = std::stoi(commandName.substr(MIN_VALUE_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(MAX_VALUE_PATTERN) == 0) {
+                        maxValue = std::stoi(commandName.substr(MAX_VALUE_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(UNITS_PATTERN) == 0) {
+                        units = removeQuotes(commandName.substr(UNITS_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(STEPS_PATTERN) == 0) {
+                        steps = std::stoi(commandName.substr(STEPS_PATTERN.length()));
+                        continue;
+                    } else if (commandName.find(UNLOCKED_PATTERN) == 0) {
+                        unlockedTrackbar = (commandName.substr(UNLOCKED_PATTERN.length()) == TRUE_STR);
+                        continue;
+                    } else if (commandName.find(ON_EVERY_TICK_PATTERN) == 0) {
+                        onEveryTick = (commandName.substr(ON_EVERY_TICK_PATTERN.length()) == TRUE_STR);
+                        continue;
+                    } else if (commandName.find(";") == 0) {
+                        continue;
+                    }
+        
+                    if (commandMode == TOGGLE_STR) {
+                        if (commandName.find("on:") == 0)
+                            currentSection = ON_STR;
+                        else if (commandName.find("off:") == 0)
+                            currentSection = OFF_STR;
+        
+                        if (currentSection == GLOBAL_STR) {
+                            commandsOn.push_back(cmd);
+                            commandsOff.push_back(cmd);
+                        } else if (currentSection == ON_STR) {
+                            commandsOn.push_back(cmd);
+                        } else if (currentSection == OFF_STR) {
+                            commandsOff.push_back(cmd);
+                        }
+                    } else if (commandMode == TABLE_STR) {
+                        tableData.push_back(cmd);
+                        continue;
+                    } else if (commandMode == TRACKBAR_STR || commandMode == STEP_TRACKBAR_STR || commandMode == NAMED_STEP_TRACKBAR_STR) {
+                        //commands.push_back(cmd);
+                        continue;
+                    }
+        
+                    if (cmd.size() > 1) {
+                        if (commandName == "file_source") {
+                            if (currentSection == GLOBAL_STR) {
+                                pathPattern = preprocessPath(cmd[1], packagePath);
+                                sourceType = FILE_STR;
+                            } else if (currentSection == ON_STR) {
+                                pathPatternOn = preprocessPath(cmd[1], packagePath);
+                                sourceTypeOn = FILE_STR;
+                            } else if (currentSection == OFF_STR) {
+                                pathPatternOff = preprocessPath(cmd[1], packagePath);
+                                sourceTypeOff = FILE_STR;
+                            }
+                        } else if (commandName == "package_source") {
+                            packageSource = preprocessPath(cmd[1], packagePath);
+                        }
+                    }
+                }
+            }
+
             
             if (isFileOrDirectory(packageConfigIniPath)) {
                 packageConfigData = getParsedDataFromIniFile(packageConfigIniPath);
@@ -2269,7 +2413,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             
             if (!skipSection && !skipSystem) { // for skipping the drawing of sections
                 if (commandMode == TABLE_STR) {
-                    addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground);
+                    addTable(list, tableData, packagePath, tableColumnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground, useHeaderIndent);
                     continue;
                 } else if (commandMode == TRACKBAR_STR) {
                     list->addItem(new tsl::elm::TrackBar(optionName, packagePath, minValue, maxValue, units, interpretAndExecuteCommands, getSourceReplacement, commands, option.first, false, false, -1, unlockedTrackbar, onEveryTick));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3176,6 +3176,7 @@ public:
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, USE_LAUNCH_ARGS_STR, FALSE_STR);
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, LAUNCH_ARGS_STR, "");
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, "custom_name", "");
+                        setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, "custom_version", "");
                         const auto& [result, overlayName, overlayVersion] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                         if (result != ResultSuccess) continue;
                         overlayList.insert("0020"+(overlayName)+":" + overlayFileName);
@@ -3186,8 +3187,9 @@ public:
                         const std::string& useLaunchArgs = getValueOrDefault(it->second, USE_LAUNCH_ARGS_STR, FALSE_STR);
                         const std::string& launchArgs = getValueOrDefault(it->second, LAUNCH_ARGS_STR, "");
                         const std::string& customName = getValueOrDefault(it->second, "custom_name", "");
+                        const std::string& customVersion = getValueOrDefault(it->second, "custom_version", "");
                         
-                        std::string assignedOverlayName;
+                        std::string assignedOverlayName, assignedOverlayVersion;
 
                         const auto& [result, overlayName, overlayVersion] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                         if (result != ResultSuccess) continue;
@@ -3196,10 +3198,15 @@ public:
                             assignedOverlayName = customName;
                         } else
                             assignedOverlayName = overlayName;
+
+                        if (!customVersion.empty()){
+                            assignedOverlayVersion = customVersion;
+                        } else
+                            assignedOverlayVersion = overlayVersion;
                         
-                        const std::string& baseOverlayInfo = priority + (assignedOverlayName) + ":" + assignedOverlayName + ":" + overlayVersion + ":" + overlayFileName;
+                        const std::string& baseOverlayInfo = priority + (assignedOverlayName) + ":" + assignedOverlayName + ":" + assignedOverlayVersion + ":" + overlayFileName;
                         const std::string& fullOverlayInfo = (starred == TRUE_STR) ? "-1:" + baseOverlayInfo : baseOverlayInfo;
-                
+                        
                         if (hide == FALSE_STR) {
                             overlayList.insert(fullOverlayInfo);
                         } else {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -2424,7 +2424,6 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             }
             
             
-
             // Get Option name and footer
             if (optionName.front() == '*') { 
                 useSelection = true;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -669,7 +669,7 @@ public:
                 deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
             
             versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
-            
+
             if (!versionLabel.empty() && versionLabel != "0")
                 setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version", versionLabel);
             else {
@@ -2178,8 +2178,17 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                             skipSection = false;
                             lastSection = "Commands";
                         }
-                        // Create reference to PackageMenu with dropdownSection set to optionName
-                        listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)), DROPDOWN_SYMBOL);
+                        commandFooter = parseValueFromIniSection(packageConfigIniPath, optionName, FOOTER_STR);
+                        // override loading of the command footer
+                        if (!commandFooter.empty()){
+                            footer = commandFooter;
+                            listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)));
+                            listItem->setValue(footer);
+                        } else {
+                            footer = DROPDOWN_SYMBOL;
+                            // Create reference to PackageMenu with dropdownSection set to optionName
+                            listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)), footer);
+                        }
                         
                         if (packageMenuMode)
                             listItem->setClickListener([packagePath, currentPage, packageName, optionName](s64 keys) {
@@ -2415,6 +2424,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             }
             
             
+
             // Get Option name and footer
             if (optionName.front() == '*') { 
                 useSelection = true;
@@ -2430,11 +2440,16 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             
             if ((commandMode == OPTION_STR) || (commandMode == SLOT_STR) || (commandMode == TOGGLE_STR && !useSelection)) {
                 // override loading of the command footer
-                if (!commandFooter.empty())
-                    footer = commandFooter;
-                else
-                    footer = OPTION_SYMBOL;
+                //if (!commandFooter.empty())
+                //    footer = commandFooter;
+                //else
+                footer = OPTION_SYMBOL;
             }
+
+            // override loading of the command footer
+            if (!commandFooter.empty())
+                footer = commandFooter;
+
             skipSystem = false;
             if (commandSystem == ERISTA_STR && !usingErista) {
                 skipSystem = true;
@@ -2528,13 +2543,14 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                 }
                 if (useSelection) { // For wildcard commands (dropdown menus)
 
-                    if ((footer == DROPDOWN_SYMBOL) || (footer.empty())) {
-                        if (!commandFooter.empty())
-                            footer = commandFooter;
+                    if ((footer == DROPDOWN_SYMBOL) || (footer.empty()) || footer == commandFooter) {
+                        //if (!commandFooter.empty())
+                        //    footer = commandFooter;
                         listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName), footer);
                     }
                     else {
                         listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName));
+
                         if (commandMode == OPTION_STR)
                             listItem->setValue(footer);
                         else
@@ -2571,7 +2587,11 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                             return false;
                         });
                     } else {
-                        
+                        //if (!commandFooter.empty()) {
+                        //    listItem->setValue(commandFooter, true);
+                        //    //listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName), footer);
+                        //}
+                        //listItem->setValue("TEST", true);
                         //std::vector<std::vector<std::string>> modifiedCommands = getModifyCommands(option.second, pathReplace);
                         listItem->setClickListener([commands, keyName = option.first, dropdownSection, packagePath,  packageName, footer, lastSection, listItemRaw = listItem.get()](uint64_t keys) {
                             //listItemPtr = std::shared_ptr<tsl::elm::ListItem>(listItem.get(), [](auto*){})](uint64_t keys) {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -463,13 +463,16 @@ private:
             if (keys & KEY_A) {
 
                 if (targetMenu == "softwareUpdateMenu") {
-                    std::vector<std::vector<std::string>> interpreterCommands = {
-                        {"try:"},
-                        {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH+"release.json"},
-                    };
-                    interpretAndExecuteCommands(std::move(interpreterCommands), "", "");
+                    executeCommands({
+                        {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH + "release.json"}
+                    });
+                } else if (targetMenu == "themeMenu") {
+                    if (!isFileOrDirectory(THEMES_PATH+"ultra.ini")) {
+                        executeCommands({
+                            {"download", INCLUDED_THEME_URL, THEMES_PATH}
+                        });
+                    }
                 }
-
 
                 tsl::changeTo<UltrahandSettingsMenu>(targetMenu);
                 selectedListItem = std::shared_ptr<tsl::elm::ListItem>(listItemRaw, [](auto*) {});
@@ -552,7 +555,7 @@ private:
                 if (movePath == LANG_PATH) { // for language update commands
                     interpreterCommands.push_back({"unzip", targetPath, movePath});
                 } else {
-                    interpreterCommands.push_back({"download", INCLUDED_THEME_URL, THEMES_PATH});
+                    //interpreterCommands.push_back({"download", INCLUDED_THEME_URL, THEMES_PATH});
                     interpreterCommands.push_back({"move", targetPath, movePath});
                 }
                 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -668,7 +668,7 @@ public:
             else {
                 versionLabel = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version");
             }
-            deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
+            //deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
 
             //versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -662,13 +662,15 @@ public:
                 index++;
             }
         } else if (dropdownSelection == "softwareUpdateMenu") {
-            std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name"));
+            std::string versionLabel = trim(cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name")));
             if (!versionLabel.empty() && versionLabel != "0")
-                moveFileOrDirectory(SETTINGS_PATH+"latest_release.json", SETTINGS_PATH+"release.json");
-            else
-                deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
+                setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version", versionLabel);
             
-            versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
+            if (versionLabel.empty())
+                versionLabel = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version");
+
+            //versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
+
 
             list->addItem(new tsl::elm::CategoryHeader(SOFTWARE_UPDATE));
             addUpdateButton(list, UPDATE_ULTRAHAND, ULTRAHAND_REPO_URL + "releases/latest/download/ovlmenu.ovl", "/config/ultrahand/downloads/ovlmenu.ovl", "/switch/.overlays/ovlmenu.ovl", versionLabel);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -664,14 +664,17 @@ public:
         } else if (dropdownSelection == "softwareUpdateMenu") {
             std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name"));
             if (!versionLabel.empty() && versionLabel != "0")
+                moveFileOrDirectory(SETTINGS_PATH+"latest_release.json", SETTINGS_PATH+"release.json");
+            else
+                deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
+            
+            versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
+            
+            if (!versionLabel.empty() && versionLabel != "0")
                 setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version", versionLabel);
             else {
                 versionLabel = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "latest_version");
             }
-            //deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
-
-            //versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
-
 
             list->addItem(new tsl::elm::CategoryHeader(SOFTWARE_UPDATE));
             addUpdateButton(list, UPDATE_ULTRAHAND, ULTRAHAND_REPO_URL + "releases/latest/download/ovlmenu.ovl", "/config/ultrahand/downloads/ovlmenu.ovl", "/switch/.overlays/ovlmenu.ovl", versionLabel);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -461,6 +461,16 @@ private:
                 simulatedSelect = false;
             }
             if (keys & KEY_A) {
+
+                if (targetMenu == "softwareUpdateMenu") {
+                    std::vector<std::vector<std::string>> interpreterCommands = {
+                        {"try:"},
+                        {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH+"release.json"},
+                    };
+                    interpretAndExecuteCommands(std::move(interpreterCommands), "", "");
+                }
+
+
                 tsl::changeTo<UltrahandSettingsMenu>(targetMenu);
                 selectedListItem = std::shared_ptr<tsl::elm::ListItem>(listItemRaw, [](auto*) {});
                 simulatedSelectComplete = true;
@@ -516,8 +526,10 @@ private:
     }
 
 
-    void addUpdateButton(std::unique_ptr<tsl::elm::List>& list, const std::string& title, const std::string& downloadUrl, const std::string& targetPath, const std::string& movePath) {
+    void addUpdateButton(std::unique_ptr<tsl::elm::List>& list, const std::string& title, const std::string& downloadUrl, const std::string& targetPath, const std::string& movePath, const std::string& versionLabel) {
         auto listItem = std::make_unique<tsl::elm::ListItem>(title);
+        listItem->setValue(versionLabel, true);
+
         listItem->setClickListener([listItemRaw = listItem.get(), downloadUrl, targetPath, movePath](uint64_t keys) {
             if (runningInterpreter.load(std::memory_order_acquire)) {
                 return false;
@@ -530,7 +542,6 @@ private:
             std::vector<std::vector<std::string>> interpreterCommands;
             if (keys & KEY_A) {
                 isDownloadCommand = true;
-                
                 
                 interpreterCommands = {
                     {"try:"},
@@ -646,9 +657,11 @@ public:
                 index++;
             }
         } else if (dropdownSelection == "softwareUpdateMenu") {
+            std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
+
             list->addItem(new tsl::elm::CategoryHeader(SOFTWARE_UPDATE));
-            addUpdateButton(list, UPDATE_ULTRAHAND, ULTRAHAND_REPO_URL + "releases/latest/download/ovlmenu.ovl", "/config/ultrahand/downloads/ovlmenu.ovl", "/switch/.overlays/ovlmenu.ovl");
-            addUpdateButton(list, UPDATE_LANGUAGES, ULTRAHAND_REPO_URL + "releases/latest/download/lang.zip", "/config/ultrahand/downloads/lang.zip", LANG_PATH);
+            addUpdateButton(list, UPDATE_ULTRAHAND, ULTRAHAND_REPO_URL + "releases/latest/download/ovlmenu.ovl", "/config/ultrahand/downloads/ovlmenu.ovl", "/switch/.overlays/ovlmenu.ovl", versionLabel);
+            addUpdateButton(list, UPDATE_LANGUAGES, ULTRAHAND_REPO_URL + "releases/latest/download/lang.zip", "/config/ultrahand/downloads/lang.zip", LANG_PATH, versionLabel);
 
             PackageHeader overlayHeader;
             overlayHeader.title = "Ultrahand Overlay";

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -464,11 +464,13 @@ private:
 
                 if (targetMenu == "softwareUpdateMenu") {
                     executeCommands({
-                        {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH + "release.json"}
+                        {"try:"},
+                        {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH + "latest_release.json"}
                     });
                 } else if (targetMenu == "themeMenu") {
                     if (!isFileOrDirectory(THEMES_PATH+"ultra.ini")) {
                         executeCommands({
+                            {"try:"},
                             {"download", INCLUDED_THEME_URL, THEMES_PATH}
                         });
                     }
@@ -660,7 +662,13 @@ public:
                 index++;
             }
         } else if (dropdownSelection == "softwareUpdateMenu") {
-            std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
+            std::string versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"latest_release.json").c_str(), "tag_name"));
+            if (!versionLabel.empty() && versionLabel != "0")
+                moveFileOrDirectory(SETTINGS_PATH+"latest_release.json", SETTINGS_PATH+"release.json");
+            else
+                deleteFileOrDirectory(SETTINGS_PATH+"latest_release.json");
+            
+            versionLabel = cleanVersionLabel(getStringFromJsonFile((SETTINGS_PATH+"release.json").c_str(), "tag_name"));
 
             list->addItem(new tsl::elm::CategoryHeader(SOFTWARE_UPDATE));
             addUpdateButton(list, UPDATE_ULTRAHAND, ULTRAHAND_REPO_URL + "releases/latest/download/ovlmenu.ovl", "/config/ultrahand/downloads/ovlmenu.ovl", "/switch/.overlays/ovlmenu.ovl", versionLabel);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3175,6 +3175,7 @@ public:
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, HIDE_STR, FALSE_STR);
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, USE_LAUNCH_ARGS_STR, FALSE_STR);
                         setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, LAUNCH_ARGS_STR, "");
+                        setIniFileValue(OVERLAYS_INI_FILEPATH, overlayFileName, "custom_name", "");
                         const auto& [result, overlayName, overlayVersion] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                         if (result != ResultSuccess) continue;
                         overlayList.insert("0020"+(overlayName)+":" + overlayFileName);
@@ -3184,11 +3185,19 @@ public:
                         const std::string& hide = getValueOrDefault(it->second, HIDE_STR, FALSE_STR);
                         const std::string& useLaunchArgs = getValueOrDefault(it->second, USE_LAUNCH_ARGS_STR, FALSE_STR);
                         const std::string& launchArgs = getValueOrDefault(it->second, LAUNCH_ARGS_STR, "");
+                        const std::string& customName = getValueOrDefault(it->second, "custom_name", "");
                         
+                        std::string assignedOverlayName;
+
                         const auto& [result, overlayName, overlayVersion] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                         if (result != ResultSuccess) continue;
+
+                        if (!customName.empty()){
+                            assignedOverlayName = customName;
+                        } else
+                            assignedOverlayName = overlayName;
                         
-                        const std::string& baseOverlayInfo = priority + (overlayName) + ":" + overlayName + ":" + overlayVersion + ":" + overlayFileName;
+                        const std::string& baseOverlayInfo = priority + (assignedOverlayName) + ":" + assignedOverlayName + ":" + overlayVersion + ":" + overlayFileName;
                         const std::string& fullOverlayInfo = (starred == TRUE_STR) ? "-1:" + baseOverlayInfo : baseOverlayInfo;
                 
                         if (hide == FALSE_STR) {

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -189,6 +189,10 @@ void initializeTheme(std::string themeIniPath = THEME_CONFIG_INI_PATH) {
             setIniFileValue(themeIniPath, THEME_STR, key, value);
         }
     }
+
+    if (!isFileOrDirectory(THEMES_PATH)) {
+        createDirectory(THEMES_PATH);
+    }
 }
 
 
@@ -719,7 +723,8 @@ std::vector<std::pair<std::string, std::vector<std::vector<std::string>>>> loadO
         std::ofstream configFileOut(configIniPath);
         if (configFileOut) {
             //configFileOut << "[Reboot]\nreboot\n\n[Shutdown]\nshutdown\n";
-            configFileOut << "[*Reboot To]\nini_file_source /bootloader/hekate_ipl.ini\nfilter config\nreboot boot '{ini_file_source(*)}'\n\n[Shutdown]\nshutdown\n";
+            //configFileOut << "[*Reboot To]\nini_file_source /bootloader/hekate_ipl.ini\nfilter config\nreboot boot '{ini_file_source(*)}'\n\n[Shutdown]\nshutdown\n";
+            configFileOut << "[*Reboot To]\n[*Boot Entry]\nini_file_source /bootloader/hekate_ipl.ini\nfilter config\nreboot boot '{ini_file_source(*)}'\n[Hekate]\nreboot HEKATE\n[Hekate UMS]\nreboot UMS\n\n[Commands]\n[Shutdown]\nshutdown\n";
             //configFileOut << "[*Reboot]\n[HOS Reboot]\nreboot\n[Hekate Reboot]\nreboot HEKATE\n[UMS Reboot]\nreboot UMS\n\n[Commands]\n[Shutdown]\nshutdown";
             configFileOut.close();
         }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -306,7 +306,7 @@ std::tuple<Result, std::string, std::string> getOverlayInfo(const std::string& f
 
 void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::string>& sectionLines, const std::vector<std::string>& infoLines,
     const size_t& columnOffset = 120, const size_t& startGap = 20, const size_t& endGap = 3, const size_t& newlineGap = 0,
-    const std::string& tableSectionTextColor = DEFAULT_STR, const std::string& tableInfoTextColor = DEFAULT_STR, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false) {
+    const std::string& tableSectionTextColor = DEFAULT_STR, const std::string& tableInfoTextColor = DEFAULT_STR, const std::string& alignment = LEFT_STR, const bool& hideTableBackground = false, const bool& useHeaderIndent = false) {
 
     size_t lineHeight = 16;
     size_t fontSize = 16;
@@ -320,6 +320,14 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
     if (tableSectionTextColor != DEFAULT_STR) {
         if (tableSectionTextColor == "warning") {
             alternateSectionTextColor = tsl::warningTextColor;
+        } else if (tableSectionTextColor == "text") {
+            alternateSectionTextColor = tsl::defaultTextColor;
+        } else if (tableSectionTextColor == "on_value") {
+            alternateSectionTextColor = tsl::onTextColor;
+        } else if (tableSectionTextColor == "off_value") {
+            alternateSectionTextColor = tsl::offTextColor;
+        } else if (tableSectionTextColor == "header") {
+            alternateSectionTextColor = tsl::headerTextColor;
         } else {
             alternateSectionTextColor = tsl::RGB888(tableSectionTextColor);
         }
@@ -328,6 +336,14 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
     if (tableInfoTextColor != DEFAULT_STR) {
         if (tableInfoTextColor == "warning") {
             alternateInfoTextColor = tsl::warningTextColor;
+        } else if (tableSectionTextColor == "text") {
+            alternateInfoTextColor = tsl::defaultTextColor;
+        } else if (tableSectionTextColor == "on_value") {
+            alternateInfoTextColor = tsl::onTextColor;
+        } else if (tableSectionTextColor == "off_value") {
+            alternateInfoTextColor = tsl::offTextColor;
+        } else if (tableSectionTextColor == "header") {
+            alternateInfoTextColor = tsl::headerTextColor;
         } else {
             alternateInfoTextColor = tsl::RGB888(tableInfoTextColor);
         }
@@ -368,6 +384,8 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
                 infoXOffsets[i] = columnOffset + (xMax - infoStringWidths[i]) / 2;
             }
         }
+        if (useHeaderIndent)
+            renderer->drawRect(x-2, y+2, 3, 23, renderer->a(tsl::headerSeparatorColor));
 
         for (size_t i = 0; i < sectionLines.size(); ++i) {
             renderer->drawString(sectionLines[i].c_str(), false, x + 12, y + yOffsets[i], fontSize, renderer->a((tableSectionTextColor == DEFAULT_STR) ? sectionTextColor : alternateSectionTextColor));
@@ -384,7 +402,8 @@ void drawTable(std::unique_ptr<tsl::elm::List>& list, const std::vector<std::str
 void applyPlaceholderReplacement(std::vector<std::string>& cmd, std::string hexPath, std::string iniPath, std::string listString, std::string listPath, std::string jsonString, std::string jsonPath);
 
 void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std::string>>& tableData,
-    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0, const std::string& tableSectionTextColor=DEFAULT_STR, const std::string& tableInfoTextColor=DEFAULT_STR, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false) {
+    const std::string& packagePath, const size_t& columnOffset=160, const size_t& tableStartGap=20, const size_t& tableEndGap=3, const size_t& tableSpacing=0,
+    const std::string& tableSectionTextColor=DEFAULT_STR, const std::string& tableInfoTextColor=DEFAULT_STR, const std::string& tableAlignment=RIGHT_STR, const bool& hideTableBackground = false, const bool& useHeaderIndent = false) {
 
     //std::string sectionString, infoString;
     std::vector<std::string> sectionLines, infoLines;
@@ -477,7 +496,7 @@ void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std
     // seperate sectionString and info string.  the sections will be on the left side of the "=", the info will be on the right side of the "=" within the string.  the end of an entry will be met with a newline (except for the very last entry). 
     // sectionString and infoString will each have equal newlines (denoting )
 
-    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground);
+    drawTable(list, sectionLines, infoLines, columnOffset, tableStartGap, tableEndGap, tableSpacing, tableSectionTextColor, tableInfoTextColor, tableAlignment, hideTableBackground, useHeaderIndent);
 }
 
 

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -128,33 +128,33 @@ void powerOffAllControllers() {
     btmExit();
 }
 
-std::unordered_map<std::string, std::string> createButtonCharMap() {
-    std::unordered_map<std::string, std::string> map;
-    for (const auto& keyInfo : tsl::impl::KEYS_INFO) {
-        map[keyInfo.name] = keyInfo.glyph;
-    }
-    return map;
-}
-
-std::unordered_map<std::string, std::string> buttonCharMap = createButtonCharMap();
-
-
-std::string convertComboToUnicode(const std::string& combo) {
-
-    std::istringstream iss(combo);
-    std::string token;
-    std::string unicodeCombo;
-
-    while (std::getline(iss, token, '+')) {
-        unicodeCombo += buttonCharMap[trim(token)] + "+";
-    }
-
-    if (!unicodeCombo.empty()) {
-        unicodeCombo.pop_back();  // Remove the trailing '+'
-    }
-
-    return unicodeCombo;
-}
+//std::unordered_map<std::string, std::string> createButtonCharMap() {
+//    std::unordered_map<std::string, std::string> map;
+//    for (const auto& keyInfo : tsl::impl::KEYS_INFO) {
+//        map[keyInfo.name] = keyInfo.glyph;
+//    }
+//    return map;
+//}
+//
+//std::unordered_map<std::string, std::string> buttonCharMap = createButtonCharMap();
+//
+//
+//std::string convertComboToUnicode(const std::string& combo) {
+//
+//    std::istringstream iss(combo);
+//    std::string token;
+//    std::string unicodeCombo;
+//
+//    while (std::getline(iss, token, '+')) {
+//        unicodeCombo += buttonCharMap[trim(token)] + "+";
+//    }
+//
+//    if (!unicodeCombo.empty()) {
+//        unicodeCombo.pop_back();  // Remove the trailing '+'
+//    }
+//
+//    return unicodeCombo;
+//}
 
 
 


### PR DESCRIPTION
List of changes:
1. Dropdown and forwarder commands can now use custom labels/footers by using `footer=` with a value other than `null` in the package's `config.ini`.
2. Custom name and version labels for overlays and packages can now be set in `/config/ultrahand/overlays.ini` and `/config/ultrahand/packages.ini` by using options `custom_name=` and `custom_version=`.
    - Overlays will only be renamed when displayed on the menu.  Direct modification of the overlay is still required for any re-naming of the overlay modules themselves.
    - Packages will now assume names in the following priorities.
        i. Priority 0: Custom names and versions written in `packages.ini`.
        ii. Priority 1: Package name stated in the header in the `package.ini` file for the Ultrahand package.
        iii. Priority 2: If none of the above, it will assume the name based upon the Ultrahand package folder.
    - If left empty, custom name and version parameters will be unused.
3. New option for table `;header_indent=` for drawing a single header indent on left side of the line.
    - This is meant to be used on one line "header-like" tables.
4. New table text color options for `info_text_color` and `section_text_color`.
    - `text` : Ultrahand theme text color used for default text.
    - `header` : Ultrahand theme text color used for headers.
    - `on_value` : Ultrahand theme color for `On` values / values.
    - `off_value` : Ultrahand theme color for `Off` values / version labels.
5. Key combo string representations in packages will now return their symbolic representation.
6. Software update menu will now pull an indicator for the latest Ultrahand Overlay version from the GitHub API.
7. Themes `classic.ini` and `ultra.ini` will now be auto-downloaded when opening the Theme manager if they do not exist.
8. Downloads are now stored in a temporary state until completion.  After completion, they are then moved into place.
    - This should help with failed downloads and files being removed/replaced after a failed download to an existing filepath.
9. The packages menu commands section now utilizes the same core logic as the packages themselves. (code optimization)
10. Various subtle UI positioning corrections and bug fixes.
    - Bug fix for cursor jumping/sliding after using hotkeys (with a d-pad down button) in games.