### PR TITLE
Development for v1.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE	:= Ultrahand
 APP_AUTHOR	:= ppkantorski
-APP_VERSION	:= 1.7.4
+APP_VERSION	:= 1.7.5
 TARGET	    := ovlmenu
 BUILD	    := build
 SOURCES	    := source common 

--- a/lang/de.json
+++ b/lang/de.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "Auf einem Befehl",
     "ON_OVERLAY_PACKAGE": "Auf einem OVL/PKT",
     "EFFECTS": "Effekte",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Fortschrittsanimation",
     "EMPTY": "Leer",

--- a/lang/en.json
+++ b/lang/en.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Effects",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Progress Animation",
     "EMPTY": "Empty",

--- a/lang/es.json
+++ b/lang/es.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Efectos",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Animación de progreso",
     "EMPTY": "Vacío",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Effets",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Animation de progression",
     "EMPTY": "Vide",

--- a/lang/it.json
+++ b/lang/it.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Effetti",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Animazione di progresso",
     "EMPTY": "Vuoto",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "コマンド実行時に",
     "ON_OVERLAY_PACKAGE": "オンOL/PK",
     "EFFECTS": "エフェクト",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "進行状況のアニメーション",
     "EMPTY": "空っぽ",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "명령어",
     "ON_OVERLAY_PACKAGE": "오버레이/패키지",
     "EFFECTS": "효과",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "진행 애니메이션",
     "EMPTY": "비어 있는",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Effecten",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Voortgangsanimatie",
     "EMPTY": "Leeg",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "na poleceniu",
     "ON_OVERLAY_PACKAGE": "na nakładce/paczce",
     "EFFECTS": "Efekty",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Animacja postępu",
     "EMPTY": "Puste",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "on a command",
     "ON_OVERLAY_PACKAGE": "on overlay/package",
     "EFFECTS": "Efeitos",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Animação de progresso",
     "EMPTY": "Vazio",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "на команде",
     "ON_OVERLAY_PACKAGE": "на оверлее/пакете",
     "EFFECTS": "Эффекты",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "Анимация Прогресса",
     "EMPTY": "Пустой",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "在插件包的命令中",
     "ON_OVERLAY_PACKAGE": "在单个插件或者插件包中",
     "EFFECTS": "命令效果显示",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "进度条震动特效",
     "EMPTY": "空白的文件",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -96,6 +96,7 @@
     "ON_A_COMMAND": "在插件包的命令中",
     "ON_OVERLAY_PACKAGE": "在單個插件或者插件包中",
     "EFFECTS": "效果",
+    "SWIPE_TO_OPEN": "Swipe to Open",
     "RIGHT_SIDE_MODE": "Right-side Mode",
     "PROGRESS_ANIMATION": "進度動畫",
     "EMPTY": "空",

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -7304,11 +7304,11 @@ namespace tsl {
                         // Check if the touch is within bounds for left-to-right swipe within the time window
                         if (useSwipeToOpen && elapsedTime <= TOUCH_THREHELD_MS) {
                             if (lastTouchX != 0 && currentTouch.x != 0) {
-                                if (layerEdge == 0 && currentTouch.x > SWIPE_RIGHT_BOUND + 80 && lastTouchX <= SWIPE_RIGHT_BOUND) {
+                                if (layerEdge == 0 && currentTouch.x > SWIPE_RIGHT_BOUND + 90 && lastTouchX <= SWIPE_RIGHT_BOUND) {
                                     eventFire(&shData->comboEvent);
                                 }
                                 // Check if the touch is within bounds for right-to-left swipe within the time window
-                                else if (layerEdge > 0 && currentTouch.x < SWIPE_LEFT_BOUND - 80 && lastTouchX >= SWIPE_LEFT_BOUND) {
+                                else if (layerEdge > 0 && currentTouch.x < SWIPE_LEFT_BOUND - 90 && lastTouchX >= SWIPE_LEFT_BOUND) {
                                     eventFire(&shData->comboEvent);
                                 }
                             }

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -68,6 +68,40 @@
 //uint64_t RAM_Used_system_u = 0;
 //uint64_t RAM_Total_system_u = 0;
 
+#include <switch.h>
+#include <string>
+
+std::string getTitleIdAsString() {
+    Result rc;
+    u64 pid = 0;
+    u64 tid = 0;
+
+    // The Process Management service is initialized before (as per your setup)
+    // Get the current application process ID
+    rc = pmdmntGetApplicationProcessId(&pid);
+    if (R_FAILED(rc)) {
+        return NULL_STR;
+    }
+
+    rc = pminfoInitialize();
+    if (R_FAILED(rc)) {
+        return NULL_STR;
+    }
+
+    // Use pminfoGetProgramId to retrieve the Title ID (Program ID)
+    rc = pminfoGetProgramId(&tid, pid);
+    if (R_FAILED(rc)) {
+        pminfoExit();
+        return NULL_STR;
+    }
+    pminfoExit();
+
+    // Convert the Title ID to a string and return it
+    char titleIdStr[17];  // 16 characters for the Title ID + null terminator
+    snprintf(titleIdStr, sizeof(titleIdStr), "%016lX", tid);
+    return std::string(titleIdStr);
+}
+
 static bool internalTouchReleased = true;
 static u32 layerEdge = 0;
 static bool useRightAlignment = false;
@@ -2002,6 +2036,7 @@ namespace tsl {
                     hidsysEnableAppletToGetInput(!enabled, appletAruid);
             }
             
+
             pmdmntGetApplicationProcessId(&applicationAruid);
             hidsysEnableAppletToGetInput(!enabled, applicationAruid);
             

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -3853,8 +3853,8 @@ namespace tsl {
                     }
                     if (activePercentage > 0){
                         renderer->drawRect(this->getX() + x + 4, this->getY() + y, (this->getWidth()- 12)*(activePercentage/100.0f), this->getHeight(), a(progressColor));
-                        //if (activePercentage == 100.0f) {
-                        //    resetPercentages();
+                        //if (copyPercentage == 100.0f) {
+                        //    copyPercentage = -1;
                         //}
                     }
 

--- a/lib/libtesla/include/tesla.hpp
+++ b/lib/libtesla/include/tesla.hpp
@@ -7265,7 +7265,7 @@ namespace tsl {
             static const int SWIPE_RIGHT_BOUND = 16;  // 16 + 80
             static const int SWIPE_LEFT_BOUND = (1280 - 16);
             static size_t elapsedTime = 0;
-            static const size_t TOUCH_THREHELD_MS = 150; 
+            static const size_t TOUCH_THREHELD_MS = 180; 
 
             s32 idx;
             Result rc;

--- a/lib/libultra/include/download_funcs.hpp
+++ b/lib/libultra/include/download_funcs.hpp
@@ -254,6 +254,7 @@ bool unzipFile(const std::string& zipFilePath, const std::string& toDestination)
     std::unique_ptr<ZZIP_FILE, ZzipFileDeleter> file;
     std::ofstream outputFile;
 
+    auto it = extractedFilePath.end();
     // Second pass: Extract files and update progress
     while (zzip_dir_read(dir.get(), &entry)) {
         if (entry.d_name[0] == '\0') continue; // Skip empty entries
@@ -262,7 +263,7 @@ bool unzipFile(const std::string& zipFilePath, const std::string& toDestination)
 
         // Remove invalid characters
         extractedFilePath = toDestination + fileName;
-        auto it = extractedFilePath.begin() + std::min(extractedFilePath.find(ROOT_PATH) + 5, extractedFilePath.size());
+        it = extractedFilePath.begin() + std::min(extractedFilePath.find(ROOT_PATH) + 5, extractedFilePath.size());
         extractedFilePath.erase(std::remove_if(it, extractedFilePath.end(), [](char c) {
             return c == ':' || c == '*' || c == '?' || c == '\"' || c == '<' || c == '>' || c == '|';
         }), extractedFilePath.end());

--- a/lib/libultra/include/get_funcs.hpp
+++ b/lib/libultra/include/get_funcs.hpp
@@ -96,7 +96,9 @@ inline std::string getValueFromLine(const std::string& line) {
     size_t equalsPos = line.rfind('=');
     if (equalsPos != std::string::npos && equalsPos + 1 < line.size()) {
         // Directly return the trimmed substring after '='
-        return trim(line.substr(equalsPos + 1));
+        std::string newLine = line.substr(equalsPos + 1);
+        trim(newLine);
+        return newLine;
     }
     return ""; // Return an empty string if '=' is not found or no content after '='
 }

--- a/lib/libultra/include/hex_funcs.hpp
+++ b/lib/libultra/include/hex_funcs.hpp
@@ -473,7 +473,8 @@ std::string replaceHexPlaceholder(const std::string& arg, const std::string& hex
         std::string component;
         
         while (std::getline(componentStream, component, ',')) {
-            components.push_back(trim(component));
+            trim(component);
+            components.push_back(component);
         }
         
         if (components.size() == 3) {

--- a/lib/libultra/include/ini_funcs.hpp
+++ b/lib/libultra/include/ini_funcs.hpp
@@ -91,7 +91,10 @@ PackageHeader getPackageHeaderFromIni(const std::string& filePath) {
                 if (endPos == std::string::npos) {
                     endPos = line.length();
                 }
-                *field = removeQuotes(trim(line.substr(startPos, endPos - startPos)));
+                std::string newLine = line.substr(startPos, endPos - startPos);
+                trim(newLine);
+                removeQuotes(newLine);
+                *field = newLine;
                 break; // Break after processing the first match in a line
             }
         }
@@ -149,31 +152,35 @@ static std::map<std::string, std::map<std::string, std::string>> parseIni(const 
     auto lines = split(str, '\n');
     std::string lastHeader = "";
     
-    std::string trimmedLine;
+    //std::string trimmedLine;
     
     size_t delimiterPos;
     //std::string key, value;
     
     for (auto& line : lines) {
-        trimmedLine = trim(line);
+        trim(line);
         
-        if (trimmedLine.empty() || trimmedLine.front() == '#') {
+        if (line.empty() || line.front() == '#') {
             // Ignore empty lines and comments
             continue;
         }
         
-        if (trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            lastHeader = trimmedLine.substr(1, trimmedLine.size() - 2);
+        if (line.front() == '[' && line.back() == ']') {
+            lastHeader = line.substr(1, line.size() - 2);
             iniData[lastHeader]; // Ensures the section exists even if it remains empty
         }
         else {
-            delimiterPos = trimmedLine.find('=');
+            delimiterPos = line.find('=');
             if (delimiterPos != std::string::npos) {
                 //key = trim(trimmedLine.substr(0, delimiterPos));
                 //value = trim(trimmedLine.substr(delimiterPos + 1));
                 if (!lastHeader.empty()) {
                     //iniData[lastHeader][key] = value;
-                    iniData[lastHeader][trim(trimmedLine.substr(0, delimiterPos))] = trim(trimmedLine.substr(delimiterPos + 1));
+                    std::string newLine1 = line.substr(0, delimiterPos);
+                    trim(newLine1);
+                    std::string newLine2 = line.substr(delimiterPos + 1);
+                    trim(newLine2);
+                    iniData[lastHeader][newLine1] = newLine2;
                 }
             }
         }
@@ -202,24 +209,28 @@ std::map<std::string, std::map<std::string, std::string>> getParsedDataFromIniFi
     }
     
     std::string line, currentSection;
-    std::string trimmedLine;
+    //std::string trimmedLine;
     
     size_t delimiterPos;
     std::string key, value;
     
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
-        if (trimmedLine.empty()) continue;
+        if (line.empty()) continue;
         
-        if (trimmedLine.front() == '[' && trimmedLine.back() == ']') {
+        if (line.front() == '[' && line.back() == ']') {
             // Remove the brackets and set the current section
-            currentSection = trimmedLine.substr(1, trimmedLine.size() - 2);
+            currentSection = line.substr(1, line.size() - 2);
         } else {
-            delimiterPos = trimmedLine.find('=');
+            delimiterPos = line.find('=');
             if (delimiterPos != std::string::npos) {
-                key = trim(trimmedLine.substr(0, delimiterPos));
-                value = trim(trimmedLine.substr(delimiterPos + 1));
+                key = line.substr(0, delimiterPos);
+                trim(key);
+
+                value = line.substr(delimiterPos + 1);
+                trim(value);
+
                 parsedData[currentSection][key] = value;
             }
         }
@@ -248,28 +259,30 @@ std::map<std::string, std::string> getKeyValuePairsFromSection(const std::string
     }
     
     std::string line, currentSection;
-    std::string trimmedLine;
+    //std::string trimmedLine;
     
     size_t delimiterPos;
     std::string key, value;
     bool inTargetSection = false;  // To track if we're in the desired section
     
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
-        if (trimmedLine.empty()) continue; // Skip empty lines
+        if (line.empty()) continue; // Skip empty lines
         
-        if (trimmedLine.front() == '[' && trimmedLine.back() == ']') {
+        if (line.front() == '[' && line.back() == ']') {
             // Remove the brackets to get the section name
-            currentSection = trimmedLine.substr(1, trimmedLine.size() - 2);
+            currentSection = line.substr(1, line.size() - 2);
             // Check if this is the section we're interested in
             inTargetSection = (currentSection == sectionName);
         } else if (inTargetSection) {
             // Look for key-value pairs within the target section
-            delimiterPos = trimmedLine.find('=');
+            delimiterPos = line.find('=');
             if (delimiterPos != std::string::npos) {
-                key = trim(trimmedLine.substr(0, delimiterPos));
-                value = trim(trimmedLine.substr(delimiterPos + 1));
+                key = line.substr(0, delimiterPos);
+                trim(key);
+                value = line.substr(delimiterPos + 1);
+                trim(value);
                 sectionData[key] = value;  // Store the key-value pair
             }
         }
@@ -296,14 +309,14 @@ std::vector<std::string> parseSectionsFromIni(const std::string& filePath) {
     }
     
     std::string line;
-    std::string trimmedLine;
+    //std::string trimmedLine;
 
     while (std::getline(file, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
         // Check if the line contains a section header
-        if (!trimmedLine.empty() && trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            std::string sectionName = trimmedLine.substr(1, trimmedLine.size() - 2);
+        if (!line.empty() && line.front() == '[' && line.back() == ']') {
+            std::string sectionName = line.substr(1, line.size() - 2);
             sections.push_back(sectionName);
         }
     }
@@ -333,22 +346,24 @@ std::string parseValueFromIniSection(const std::string& filePath, const std::str
     
     size_t delimiterPos;
     std::string currentKey;
-    std::string trimmedLine;
+    //std::string trimmedLine;
     
     while (std::getline(file, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
-        if (trimmedLine.empty()) continue;
+        if (line.empty()) continue;
         
-        if (trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            currentSection = trimmedLine.substr(1, trimmedLine.size() - 2);
+        if (line.front() == '[' && line.back() == ']') {
+            currentSection = line.substr(1, line.size() - 2);
             if (currentSection != sectionName) continue;  // Skip processing other sections
         } else if (currentSection == sectionName) {
-            delimiterPos = trimmedLine.find('=');
+            delimiterPos = line.find('=');
             if (delimiterPos != std::string::npos) {
-                currentKey = trim(trimmedLine.substr(0, delimiterPos));
+                currentKey = line.substr(0, delimiterPos);
+                trim(currentKey);
                 if (currentKey == keyName) {
-                    value = trim(trimmedLine.substr(delimiterPos + 1));
+                    value = line.substr(delimiterPos + 1);
+                    trim(value);
                     break;  // Found the key, exit the loop
                 }
             }
@@ -389,21 +404,21 @@ void cleanIniFormatting(const std::string& filePath) {
     std::string line;
     bool isNewSection = false;
     
-    std::string trimmedLine;
+    //std::string trimmedLine;
     
     while (std::getline(inputFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
         // Add a newline before starting a new section, but not before the first section
-        if (!trimmedLine.empty() && trimmedLine.front() == '[' && trimmedLine.back() == ']') {
+        if (!line.empty() && line.front() == '[' && line.back() == ']') {
             if (isNewSection) {
                 outputFile << '\n'; // Add an extra newline to separate sections
             }
             isNewSection = true;
         }
         
-        if (!trimmedLine.empty()) {
-            outputFile << trimmedLine << '\n';
+        if (!line.empty()) {
+            outputFile << line << '\n';
         }
     }
     
@@ -446,18 +461,18 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
     bool firstSection = true;  // Flag to control new line before first section
     std::string line, currentSection;
     
-    std::string trimmedLine;
+    //std::string trimmedLine;
     size_t delimiterPos;
     std::string key;
     
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
         
-        if (trimmedLine.empty()) {
+        if (line.empty()) {
             continue;  // Skip empty lines but do not add them to the buffer
         }
         
-        if (trimmedLine[0] == '[' && trimmedLine.back() == ']') {
+        if (line[0] == '[' && line.back() == ']') {
             if (sectionFound && !keyFound) {
                 buffer << desiredKey << "=" << desiredValue << '\n';  // Add missing key-value pair
                 keyFound = true;
@@ -465,23 +480,24 @@ void setIniFile(const std::string& fileToEdit, const std::string& desiredSection
             if (!firstSection) {
                 buffer << '\n';  // Add a newline before the start of a new section
             }
-            currentSection = trimmedLine.substr(1, trimmedLine.size() - 2);
+            currentSection = line.substr(1, line.size() - 2);
             sectionFound = (currentSection == desiredSection);
             buffer << line << '\n';
             firstSection = false;
             continue;
         }
         
-        if (sectionFound && !keyFound && trimmedLine.find('=') != std::string::npos) {
-            delimiterPos = trimmedLine.find('=');
-            key = trim(trimmedLine.substr(0, delimiterPos));
+        if (sectionFound && !keyFound && line.find('=') != std::string::npos) {
+            delimiterPos = line.find('=');
+            key = line.substr(0, delimiterPos);
+            trim(key);
             if (key == desiredKey) {
                 keyFound = true;
-                trimmedLine = (desiredNewKey.empty() ? desiredKey : desiredNewKey) + "=" + desiredValue;
+                line = (desiredNewKey.empty() ? desiredKey : desiredNewKey) + "=" + desiredValue;
             }
         }
         
-        buffer << trimmedLine << '\n';
+        buffer << line << '\n';
     }
     
     if (!sectionFound && !keyFound) {
@@ -633,13 +649,13 @@ void renameIniSection(const std::string& filePath, const std::string& currentSec
         return;
     }
 
-    std::string line, trimmedLine, sectionName;
+    std::string line, sectionName;
 
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
 
-        if (!trimmedLine.empty() && trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            sectionName = trimmedLine.substr(1, trimmedLine.length() - 2);
+        if (!line.empty() && line.front() == '[' && line.back() == ']') {
+            sectionName = line.substr(1, line.length() - 2);
 
             if (sectionName == currentSectionName) {
                 tempFile << "[" << newSectionName << "]\n";
@@ -695,14 +711,14 @@ void removeIniSection(const std::string& filePath, const std::string& sectionNam
     std::string line, currentSection;
     bool inSectionToRemove = false;
 
-    std::string trimmedLine;
+    //std::string trimmedLine;
 
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
 
         // Check if the line represents a section
-        if (!trimmedLine.empty() && trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            currentSection = trimmedLine.substr(1, trimmedLine.length() - 2);
+        if (!line.empty() && line.front() == '[' && line.back() == ']') {
+            currentSection = line.substr(1, line.length() - 2);
 
             if (currentSection == sectionName) {
                 // Mark that we are in the section to remove
@@ -751,14 +767,14 @@ void removeIniKey(const std::string& filePath, const std::string& sectionName, c
 
     std::string line, currentSection;
     bool inTargetSection = false;
-    std::string trimmedLine;
+    //std::string trimmedLine;
 
     while (getline(configFile, line)) {
-        trimmedLine = trim(line);
+        trim(line);
 
         // Check if the line represents a section
-        if (!trimmedLine.empty() && trimmedLine.front() == '[' && trimmedLine.back() == ']') {
-            currentSection = trimmedLine.substr(1, trimmedLine.length() - 2);
+        if (!line.empty() && line.front() == '[' && line.back() == ']') {
+            currentSection = line.substr(1, line.length() - 2);
 
             if (currentSection == sectionName) {
                 // We are in the target section
@@ -768,7 +784,7 @@ void removeIniKey(const std::string& filePath, const std::string& sectionName, c
                 inTargetSection = false;
             }
             tempFile << line << '\n'; // Always write section headers
-        } else if (inTargetSection && trimmedLine.find(keyName + "=") == 0) {
+        } else if (inTargetSection && line.find(keyName + "=") == 0) {
             // If we're in the target section and the line starts with the key, skip it
             continue;
         } else {

--- a/lib/libultra/include/list_funcs.hpp
+++ b/lib/libultra/include/list_funcs.hpp
@@ -114,7 +114,9 @@ std::vector<std::string> stringToList(const std::string& str) {
         
         while (std::getline(ss, item, ',')) {
             // Trim leading and trailing spaces from each token
-            result.push_back(removeQuotes(trim(item)));
+            trim(item);
+            removeQuotes(item);
+            result.push_back(item);
         }
     }
     

--- a/lib/libultra/include/mod_funcs.hpp
+++ b/lib/libultra/include/mod_funcs.hpp
@@ -203,7 +203,7 @@ bool pchtxt2cheat(const std::string &pchtxtPath, std::string cheatName = "", std
     std::istringstream iss(pchtxt);
     std::string line;
     while (std::getline(iss, line)) {
-        line = trim(line);
+        trim(line);
         if (line.empty() || line[0] == '#') {
             continue;
         }
@@ -364,7 +364,8 @@ bool pchtxt2ips(const std::string& pchtxtPath, const std::string& outputFolder) 
     pchtxtFile.close();
 
     // Trim any newline characters from nsobid
-    nsobid = trimNewline(trim(nsobid));
+    trim(nsobid);
+    trimNewline(nsobid);
 
     std::string ipsFileName = nsobid + ".ips";
     std::string ipsFilePath = outputFolder + ipsFileName;

--- a/lib/libultra/include/path_funcs.hpp
+++ b/lib/libultra/include/path_funcs.hpp
@@ -30,6 +30,54 @@ static std::atomic<bool> abortFileOp(false);
 size_t COPY_BUFFER_SIZE = 4096*4; // Increase buffer size to 128 KB
 
 
+/**
+ * @brief Checks if a path points to a directory.
+ *
+ * This function checks if the specified path points to a directory.
+ *
+ * @param path The path to check.
+ * @return True if the path is a directory, false otherwise.
+ */
+inline bool isDirectory(const std::string& path) {
+    struct stat pathStat;
+    if (stat(path.c_str(), &pathStat) == 0) {
+        return S_ISDIR(pathStat.st_mode);
+    }
+    return false;
+}
+
+
+
+/**
+ * @brief Checks if a path points to a file.
+ *
+ * This function checks if the specified path points to a file.
+ *
+ * @param path The path to check.
+ * @return True if the path is a file, false otherwise.
+ */
+inline bool isFile(const std::string& path) {
+    struct stat pathStat;
+    if (stat(path.c_str(), &pathStat) == 0) {
+        return S_ISREG(pathStat.st_mode);
+    }
+    return false;
+}
+
+
+/**
+ * @brief Checks if a path points to a file or directory.
+ *
+ * This function checks if the specified path points to either a file or a directory.
+ *
+ * @param path The path to check.
+ * @return True if the path points to a file or directory, false otherwise.
+ */
+inline bool isFileOrDirectory(const std::string& path) {
+    struct stat buffer;
+    return (stat(path.c_str(), &buffer) == 0);
+}
+
 
 
 /**

--- a/lib/libultra/include/string_funcs.hpp
+++ b/lib/libultra/include/string_funcs.hpp
@@ -35,22 +35,22 @@
 //}
 
 // Function to remove invalid characters from file names
-inline std::string cleanFileName(const std::string& fileName) {
-    std::string cleanedFileName = fileName;
-    cleanedFileName.erase(std::remove_if(cleanedFileName.begin(), cleanedFileName.end(), [](char c) {
-        return !(std::isalnum(c) || std::isspace(c) || c == '-' || c == '_');
-    }), cleanedFileName.end());
-    return cleanedFileName;
-}
-
-// Function to clean directory names by removing invalid characters
-inline std::string cleanDirectoryName(const std::string& name) {
-    std::string cleanedName = name;
-    cleanedName.erase(std::remove_if(cleanedName.begin(), cleanedName.end(), [](char c) {
-        return !(std::isalnum(c) || std::isspace(c) || c == '-' || c == '_');
-    }), cleanedName.end());
-    return cleanedName;
-}
+//inline std::string cleanFileName(const std::string& fileName) {
+//    std::string cleanedFileName = fileName;
+//    cleanedFileName.erase(std::remove_if(cleanedFileName.begin(), cleanedFileName.end(), [](char c) {
+//        return !(std::isalnum(c) || std::isspace(c) || c == '-' || c == '_');
+//    }), cleanedFileName.end());
+//    return cleanedFileName;
+//}
+//
+//// Function to clean directory names by removing invalid characters
+//inline std::string cleanDirectoryName(const std::string& name) {
+//    std::string cleanedName = name;
+//    cleanedName.erase(std::remove_if(cleanedName.begin(), cleanedName.end(), [](char c) {
+//        return !(std::isalnum(c) || std::isspace(c) || c == '-' || c == '_');
+//    }), cleanedName.end());
+//    return cleanedName;
+//}
 
 /**
  * @brief Trims leading and trailing whitespaces from a string.
@@ -61,21 +61,28 @@ inline std::string cleanDirectoryName(const std::string& name) {
  * @param str The input string to trim.
  * @return The trimmed string.
  */
-inline std::string trim(const std::string& str) {
+inline void trim(std::string& str) {
     size_t first = str.find_first_not_of(" \t\n\r\f\v");
-    if (first == std::string::npos)
-        return {};  // Use {} to avoid an extra constructor call
+    if (first == std::string::npos) {
+        return;
+    }
 
     size_t last = str.find_last_not_of(" \t\n\r\f\v");
-    return str.substr(first, last - first + 1);
+    str = str.substr(first, last - first + 1);  // Modify the original string in place
 }
+
 
 
 // Function to trim newline characters from the end of a string
-inline std::string trimNewline(const std::string &str) {
+inline void trimNewline(std::string& str) {
     size_t end = str.find_last_not_of("\n");
-    return (end == std::string::npos) ? "" : str.substr(0, end + 1);
+    if (end == std::string::npos) {
+        str.clear();  // If the string consists entirely of newlines, clear it
+    } else {
+        str.erase(end + 1);  // Remove all characters after the last non-newline character
+    }
 }
+
 
 /**
  * @brief Removes all white spaces from a string.
@@ -107,15 +114,15 @@ inline std::string removeWhiteSpaces(const std::string& str) {
  * @param str The input string to remove quotes from.
  * @return The string with quotes removed.
  */
-inline std::string removeQuotes(const std::string& str) {
+inline void removeQuotes(std::string& str) {
     if (str.size() >= 2) {
         char frontQuote = str.front();
         char backQuote = str.back();
         if ((frontQuote == '\'' && backQuote == '\'') || (frontQuote == '"' && backQuote == '"')) {
-            return str.substr(1, str.size() - 2);
+            str.erase(0, 1);  // Remove the first character (front quote)
+            str.pop_back();   // Remove the last character (back quote)
         }
     }
-    return str;
 }
 
 
@@ -156,12 +163,12 @@ inline std::string replaceMultipleSlashes(const std::string& input) {
  * @param pathPattern The input string representing a path pattern.
  * @return The string with the leading slash removed.
  */
-inline std::string_view removeLeadingSlash(const std::string_view& pathPattern) {
-    if (!pathPattern.empty() && pathPattern[0] == '/') {
-        return pathPattern.substr(1);
-    }
-    return pathPattern;
-}
+//inline std::string_view removeLeadingSlash(const std::string_view& pathPattern) {
+//    if (!pathPattern.empty() && pathPattern[0] == '/') {
+//        return pathPattern.substr(1);
+//    }
+//    return pathPattern;
+//}
 
 /**
  * @brief Removes the trailing slash from a string if present.
@@ -171,54 +178,49 @@ inline std::string_view removeLeadingSlash(const std::string_view& pathPattern) 
  * @param pathPattern The input string representing a path pattern.
  * @return The string with the trailing slash removed.
  */
-inline std::string removeEndingSlash(const std::string& pathPattern) {
-    if (!pathPattern.empty() && pathPattern.back() == '/') {
-        return pathPattern.substr(0, pathPattern.length() - 1);
-    }
-    return pathPattern;
-}
+//inline std::string_view removeEndingSlash(const std::string& pathPattern) {
+//    if (!pathPattern.empty() && pathPattern.back() == '/') {
+//        return pathPattern.substr(0, pathPattern.length() - 1);
+//    }
+//    return pathPattern;
+//}
 
 /**
  * @brief Preprocesses a path string by replacing multiple slashes and adding "sdmc:" prefix.
  *
  * This function preprocesses a path string by removing multiple consecutive slashes,
- * adding the "sdmc:" prefix if not present, and returning the resulting string.
+ * adding the "sdmc:" prefix if not present, and modifying the input string in place.
  *
- * @param path The input path string to preprocess.
- * @return The preprocessed path string.
+ * @param path The input path string to preprocess, passed by reference.
  */
-inline std::string preprocessPath(const std::string& path, const std::string& packagePath = "") {
-    std::string formattedPath = replaceMultipleSlashes(removeQuotes(path));
+inline void preprocessPath(std::string& path, const std::string& packagePath = "") {
+    removeQuotes(path);
+    path = replaceMultipleSlashes(path);
 
     // Replace "./" at the beginning of the path with the packagePath
-    if (!packagePath.empty() && formattedPath.substr(0, 2) == "./") {
-        formattedPath = packagePath + formattedPath.substr(2);
+    if (!packagePath.empty() && path.substr(0, 2) == "./") {
+        path = packagePath + path.substr(2);
     }
 
     // Ensure all paths start with "sdmc:"
-    if (formattedPath.substr(0, 5) != "sdmc:") {
-        formattedPath = "sdmc:" + formattedPath;
+    if (path.substr(0, 5) != "sdmc:") {
+        path = "sdmc:" + path;
     }
-
-    return formattedPath;
 }
-
 
 /**
  * @brief Preprocesses a URL string by adding "https://" prefix.
  *
- * This function preprocesses a URL string by adding the "https://" prefix if not already present,
- * and returns the resulting URL string.
+ * This function preprocesses a URL string by adding the "https://" prefix if not already present.
  *
- * @param path The input URL string to preprocess.
- * @return The preprocessed URL string.
+ * @param path The input URL string to preprocess, passed by reference and modified in-place.
  */
-inline std::string preprocessUrl(const std::string& path) {
-    std::string formattedPath = removeQuotes(path);
-    if ((formattedPath.compare(0, 7, "http://") == 0) || (formattedPath.compare(0, 8, "https://") == 0)) {
-        return formattedPath;
+inline void preprocessUrl(std::string& path) {
+    removeQuotes(path);
+    if ((path.compare(0, 7, "http://") == 0) || (path.compare(0, 8, "https://") == 0)) {
+        return; // No need to modify the string if it already has a prefix
     } else {
-        return std::string("https://") + formattedPath;
+        path = "https://" + path; // Prepend "https://"
     }
 }
 
@@ -227,15 +229,13 @@ inline std::string preprocessUrl(const std::string& path) {
  *
  * This function removes the file extension (characters after the last dot) from the input filename string.
  *
- * @param filename The input filename from which to drop the extension.
- * @return The filename without the extension.
+ * @param filename The input filename from which to drop the extension, passed by reference and modified in-place.
  */
-inline std::string dropExtension(std::string filename) {
+inline void dropExtension(std::string& filename) {
     size_t lastDotPos = filename.find_last_of(".");
     if (lastDotPos != std::string::npos) {
         filename.resize(lastDotPos); // Resize the string to remove the extension
     }
-    return filename;
 }
 
 /**
@@ -251,53 +251,6 @@ inline bool startsWith(const std::string& str, const std::string& prefix) {
     return str.compare(0, prefix.length(), prefix) == 0;
 }
 
-/**
- * @brief Checks if a path points to a directory.
- *
- * This function checks if the specified path points to a directory.
- *
- * @param path The path to check.
- * @return True if the path is a directory, false otherwise.
- */
-inline bool isDirectory(const std::string& path) {
-    struct stat pathStat;
-    if (stat(path.c_str(), &pathStat) == 0) {
-        return S_ISDIR(pathStat.st_mode);
-    }
-    return false;
-}
-
-
-
-/**
- * @brief Checks if a path points to a file.
- *
- * This function checks if the specified path points to a file.
- *
- * @param path The path to check.
- * @return True if the path is a file, false otherwise.
- */
-inline bool isFile(const std::string& path) {
-    struct stat pathStat;
-    if (stat(path.c_str(), &pathStat) == 0) {
-        return S_ISREG(pathStat.st_mode);
-    }
-    return false;
-}
-
-
-/**
- * @brief Checks if a path points to a file or directory.
- *
- * This function checks if the specified path points to either a file or a directory.
- *
- * @param path The path to check.
- * @return True if the path points to a file or directory, false otherwise.
- */
-inline bool isFileOrDirectory(const std::string& path) {
-    struct stat buffer;
-    return (stat(path.c_str(), &buffer) == 0);
-}
 
 
 
@@ -379,18 +332,15 @@ inline std::string formatPriorityString(const std::string& priority, int desired
  * @brief Removes the part of the string after the first occurrence of '?' character.
  *
  * This function takes a string and removes the portion of the string that appears after
- * the first '?' character, if found. If no '?' character is present, the original string
- * is returned unchanged.
+ * the first '?' character, if found. If no '?' character is present, the string remains unchanged.
  *
- * @param input The input string from which to remove the tag.
- * @return The input string with everything after the first '?' character removed.
+ * @param input The input string from which to remove the tag, passed by reference and modified in-place.
  */
-inline std::string removeTag(const std::string &input) {
+inline void removeTag(std::string &input) {
     size_t pos = input.find('?');
     if (pos != std::string::npos) {
-        return input.substr(0, pos);
+        input.resize(pos); // Modify the string in-place to remove everything after the '?'
     }
-    return input; // Return the original string if no '?' is found.
 }
 
 
@@ -456,13 +406,13 @@ inline std::string extractTitle(const std::string& input) {
 }
 
 
-inline std::string removeFilename(const std::string& path) {
-    size_t found = path.find_last_of('/');
-    if (found != std::string::npos) {
-        return path.substr(0, found + 1);
-    }
-    return path; // If no directory separator is found, return the original path
-}
+//inline std::string removeFilename(const std::string& path) {
+//    size_t found = path.find_last_of('/');
+//    if (found != std::string::npos) {
+//        return path.substr(0, found + 1);
+//    }
+//    return path; // If no directory separator is found, return the original path
+//}
 
 
 std::vector<std::string> splitString(const std::string& str, const std::string& delimiter) {
@@ -492,7 +442,7 @@ inline std::string splitStringAtIndex(const std::string& str, const std::string&
 }
 
 
-std::string customAlign(int number) {
+inline std::string customAlign(int number) {
     std::string numStr = std::to_string(number);
     int missingDigits = 4 - numStr.length();
     return std::string(missingDigits * 2, ' ') + numStr;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -590,18 +590,21 @@ private:
                     //    {"download", LATEST_RELEASE_INFO_URL, SETTINGS_PATH}
                     //});
                     downloadFile(LATEST_RELEASE_INFO_URL, SETTINGS_PATH);
+                    downloadPercentage.store(-1, std::memory_order_release);
                 } else if (targetMenu == "themeMenu") {
                     if (!isFileOrDirectory(THEMES_PATH+"ultra.ini")) {
                         //executeCommands({
                         //    {"download", INCLUDED_THEME_FOLDER_URL+"ultra.ini", THEMES_PATH}
                         //});
                         downloadFile(INCLUDED_THEME_FOLDER_URL+"ultra.ini", THEMES_PATH);
+                        downloadPercentage.store(-1, std::memory_order_release);
                     }
                     if (!isFileOrDirectory(THEMES_PATH+"classic.ini")) {
                         //executeCommands({
                         //    {"download", INCLUDED_THEME_FOLDER_URL+"classic.ini", THEMES_PATH}
                         //});
                         downloadFile(INCLUDED_THEME_FOLDER_URL+"classic.ini", THEMES_PATH);
+                        downloadPercentage.store(-1, std::memory_order_release);
                     }
                 }
 
@@ -728,10 +731,14 @@ private:
                 reinitializeVersionLabels();
             }
             else if (iniKey == "memory_expansion") {
-                if (!isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader.zip"))
+                if (!isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader.zip")) {
                     downloadFile(NX_OVLLOADER_ZIP_URL, EXPANSION_PATH);
-                if (!isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader+.zip"))
+                    downloadPercentage.store(-1, std::memory_order_release);
+                }
+                if (!isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader+.zip")) {
                     downloadFile(NX_OVLLOADER_PLUS_ZIP_URL, EXPANSION_PATH);
+                    downloadPercentage.store(-1, std::memory_order_release);
+                }
                 if (!isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader.zip") || !isFileOrDirectory(EXPANSION_PATH + "nx-ovlloader+.zip")) {
                     listItemRaw->setState(loaderTitle == "nx-ovlloader+");
                 } else {
@@ -3351,7 +3358,7 @@ public:
                         
                         interpretAndExecuteCommands(std::move(exitCommands), packagePath, "exit");
                         resetPercentages();
-                        
+
                         if (resetCommandSuccess) {
                             commandSuccess = false;
                         }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -490,15 +490,16 @@ bool handleRunningInterpreter(uint64_t& keysHeld) {
             if (currentPercentage != lastPercentage) {
                 lastSelectedListItem->setValue(symbol + " " + std::to_string(currentPercentage) + "%");
                 lastPercentage = currentPercentage;
+                lastSymbol = symbol;
             }
             if (currentPercentage == 100) {
                 inProgress = true;  // This seems to be intended to indicate task completion, but setting 'true' here every time might be a mistake?
-                //percentage.store(-1, std::memory_order_release);
+                percentage.store(-1, std::memory_order_release);
             }
-            lastSymbol = symbol;
+            
             return true;
-        } else if (lastPercentage == 99)
-            lastSelectedListItem->setValue(lastSymbol + " 100%");
+        }// else if (lastPercentage > 0)
+         //   lastSelectedListItem->setValue(lastSymbol + " 100%");
         return false;
     };
 
@@ -776,7 +777,8 @@ public:
         if (dropdownSelection.empty()) {
             addHeader(list, MAIN_SETTINGS);
             std::string defaultLang = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, DEFAULT_LANG_STR);
-            std::string keyCombo = trim(parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, KEY_COMBO_STR));
+            std::string keyCombo = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, KEY_COMBO_STR);
+            trim(keyCombo);
             defaultLang = defaultLang.empty() ? "en" : defaultLang;
             keyCombo = keyCombo.empty() ? defaultCombos[0] : keyCombo;
 
@@ -803,7 +805,8 @@ public:
 
         } else if (dropdownSelection == "keyComboMenu") {
             addHeader(list, KEY_COMBO);
-            std::string defaultCombo = trim(parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, KEY_COMBO_STR));
+            std::string defaultCombo = parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, KEY_COMBO_STR);
+            trim(defaultCombo);
             handleSelection(list, defaultCombos, defaultCombo, KEY_COMBO_STR, "keyComboMenu");
         } else if (dropdownSelection == "languageMenu") {
             addHeader(list, LANGUAGE);
@@ -1002,7 +1005,8 @@ public:
 
             std::string themeName;
             for (const auto& themeFile : filesList) {
-                themeName = dropExtension(getNameFromPath(themeFile));
+                themeName = getNameFromPath(themeFile);
+                dropExtension(themeName);
                 if (themeName == DEFAULT_STR) continue;
                 listItem = std::make_unique<tsl::elm::ListItem>(themeName);
                 if (themeName == currentTheme) {
@@ -1082,7 +1086,8 @@ public:
 
             std::string wallpaperName;
             for (const auto& wallpaperFile : filesList) {
-                wallpaperName = dropExtension(getNameFromPath(wallpaperFile));
+                wallpaperName = getNameFromPath(wallpaperFile);
+                dropExtension(wallpaperName);
                 if (wallpaperName == DEFAULT_STR) continue;
                 listItem = std::make_unique<tsl::elm::ListItem>(wallpaperName);
                 if (wallpaperName == currentWallpaper) {
@@ -1143,8 +1148,10 @@ public:
             
             addHeader(list, EFFECTS);
 
-            useRightAlignment = (parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "right_alignment") == TRUE_STR);
+            useSwipeToOpen = (parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "swipe_to_open") == TRUE_STR);
+            createToggleListItem(list, SWIPE_TO_OPEN, useSwipeToOpen, "swipe_to_open");
 
+            useRightAlignment = (parseValueFromIniSection(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, "right_alignment") == TRUE_STR);
             rightAlignmentState = useRightAlignment;
             createToggleListItem(list, RIGHT_SIDE_MODE, useRightAlignment, "right_alignment");
 
@@ -1863,12 +1870,15 @@ public:
 
 
                     if (commandName == "ini_file") {
-                        iniFilePath = preprocessPath(cmd[1], filePath);
+                        iniFilePath = cmd[1];
+                        preprocessPath(iniFilePath, filePath);
                         continue;
                     } else if (commandName == "filter") {
-                        filterEntry = removeQuotes(cmd[1]);
-                        if (sourceType == FILE_STR)
-                            filterEntry = preprocessPath(filterEntry, filePath);
+                        filterEntry = cmd[1];
+                        removeQuotes(filterEntry);
+                        if (sourceType == FILE_STR) {
+                            preprocessPath(filterEntry, filePath);
+                        }
 
                         if (currentSection == GLOBAL_STR)
                             filterList.push_back(std::move(filterEntry));
@@ -1880,17 +1890,20 @@ public:
                         sourceType = FILE_STR;
                         if (currentSection == GLOBAL_STR) {
                             //logMessage("cmd[1]: "+cmd[1]);
-                            pathPattern = preprocessPath(cmd[1], filePath);
+                            pathPattern = cmd[1];
+                            preprocessPath(pathPattern, filePath);
                             //logMessage("pathPattern: "+pathPattern);
                             newFiles = getFilesListByWildcards(pathPattern);
                             filesList.insert(filesList.end(), newFiles.begin(), newFiles.end()); // Append new files
                         } else if (currentSection == ON_STR) {
-                            pathPatternOn = preprocessPath(cmd[1], filePath);
+                            pathPatternOn = cmd[1];
+                            preprocessPath(pathPatternOn, filePath);
                             newFilesOn = getFilesListByWildcards(pathPatternOn);
                             filesListOn.insert(filesListOn.end(), newFilesOn.begin(), newFilesOn.end()); // Append new files
                             sourceTypeOn = FILE_STR;
                         } else if (currentSection == OFF_STR) {
-                            pathPatternOff = preprocessPath(cmd[1], filePath);
+                            pathPatternOff = cmd[1];
+                            preprocessPath(pathPatternOff, filePath);
                             newFilesOff = getFilesListByWildcards(pathPatternOff);
                             filesListOff.insert(filesListOff.end(), newFilesOff.begin(), newFilesOff.end()); // Append new files
                             sourceTypeOff = FILE_STR;
@@ -1898,16 +1911,19 @@ public:
                     } else if (commandName == "json_file_source") {
                         sourceType = JSON_FILE_STR;
                         if (currentSection == GLOBAL_STR) {
-                            jsonPath = preprocessPath(cmd[1], filePath);
+                            jsonPath = cmd[1];
+                            preprocessPath(jsonPath, filePath);
                             if (cmd.size() > 2)
                                 jsonKey = cmd[2];
                         } else if (currentSection == ON_STR) {
-                            jsonPathOn = preprocessPath(cmd[1], filePath);
+                            jsonPathOn = cmd[1];
+                            preprocessPath(jsonPathOn, filePath);
                             sourceTypeOn = JSON_FILE_STR;
                             if (cmd.size() > 2)
                                 jsonKeyOn = cmd[2];
                         } else if (currentSection == OFF_STR) {
-                            jsonPathOff = preprocessPath(cmd[1], filePath);
+                            jsonPathOff = cmd[1];
+                            preprocessPath(jsonPathOff, filePath);
                             sourceTypeOff = JSON_FILE_STR;
                             if (cmd.size() > 2)
                                 jsonKeyOff = cmd[2];
@@ -1915,52 +1931,70 @@ public:
                     } else if (commandName == "list_file_source") {
                         sourceType = LIST_FILE_STR;
                         if (currentSection == GLOBAL_STR) {
-                            listPath = preprocessPath(cmd[1], filePath);
+                            listPath = cmd[1];
+                            preprocessPath(listPath, filePath);
                         } else if (currentSection == ON_STR) {
-                            listPathOn = preprocessPath(cmd[1], filePath);
+                            listPathOn = cmd[1];
+                            preprocessPath(listPathOn, filePath);
                             sourceTypeOn = LIST_FILE_STR;
                         } else if (currentSection == OFF_STR) {
-                            listPathOff = preprocessPath(cmd[1], filePath);
+                            listPathOff = cmd[1];
+                            preprocessPath(listPathOff, filePath);
                             sourceTypeOff = LIST_FILE_STR;
                         }
                     } else if (commandName == "list_source") {
                         sourceType = LIST_STR;
                         if (currentSection == GLOBAL_STR) {
-                            listString = removeQuotes(cmd[1]);
+                            listString = cmd[1];
+                            removeQuotes(listString);
                         } else if (currentSection == ON_STR) {
-                            listStringOn = removeQuotes(cmd[1]);
+                            listStringOn = cmd[1];
+                            removeQuotes(listStringOn);
                             sourceTypeOn = LIST_STR;
                         } else if (currentSection == OFF_STR) {
-                            listStringOff = removeQuotes(cmd[1]);
+                            listStringOff = cmd[1];
+                            removeQuotes(listStringOff);
                             sourceTypeOff = LIST_STR;
                         }
                     } else if (commandName == "ini_file_source") {
                         sourceType = INI_FILE_STR;
                         if (currentSection == GLOBAL_STR) {
-                            iniPath = preprocessPath(cmd[1], filePath);
+                            iniPath = cmd[1];
+                            preprocessPath(iniPath, filePath);
                         } else if (currentSection == ON_STR) {
-                            iniPathOn = preprocessPath(cmd[1], filePath);
+                            iniPathOn = cmd[1];
+                            preprocessPath(iniPathOn, filePath);
                             sourceTypeOn = INI_FILE_STR;
                         } else if (currentSection == OFF_STR) {
-                            iniPathOff = preprocessPath(cmd[1], filePath);
+                            iniPathOff = cmd[1];
+                            preprocessPath(iniPathOff, filePath);
                             sourceTypeOff = INI_FILE_STR;
                         }
                     } else if (commandName == "json_source") {
                         sourceType = JSON_STR;
                         if (currentSection == GLOBAL_STR) {
-                            jsonString = removeQuotes(cmd[1]);
-                            if (cmd.size() > 2)
-                                jsonKey = removeQuotes(cmd[2]);
+                            jsonString = cmd[1];
+                            removeQuotes(jsonString);
+                            if (cmd.size() > 2) {
+                                jsonKey = cmd[2];
+                                removeQuotes(jsonKey);
+                            }
                         } else if (currentSection == ON_STR) {
-                            jsonStringOn = removeQuotes(cmd[1]);
+                            jsonStringOn = cmd[1];
+                            removeQuotes(jsonStringOn);
                             sourceTypeOn = JSON_STR;
-                            if (cmd.size() > 2)
-                                jsonKeyOn = removeQuotes(cmd[2]);
+                            if (cmd.size() > 2) {
+                                jsonKeyOn = cmd[2];
+                                removeQuotes(jsonKeyOn);
+                            }
                         } else if (currentSection == OFF_STR) {
-                            jsonStringOff = removeQuotes(cmd[1]);
+                            jsonStringOff = cmd[1];
+                            removeQuotes(jsonStringOff);
                             sourceTypeOff = JSON_STR;
-                            if (cmd.size() > 2)
-                                jsonKeyOff = removeQuotes(cmd[2]);
+                            if (cmd.size() > 2) {
+                                jsonKeyOff = cmd[2];
+                                removeQuotes(jsonKeyOff);
+                            }
                         }
                     }
                 }
@@ -2066,8 +2100,11 @@ public:
             filterList.clear();
         }
 
-        if (commandGrouping == DEFAULT_STR)
-            addHeader(list, removeTag(specificKey.substr(1)));
+        if (commandGrouping == DEFAULT_STR) {
+            std::string cleanSpecificKey = specificKey.substr(1);
+            removeTag(cleanSpecificKey);
+            addHeader(list, cleanSpecificKey);
+        }
 
         std::unique_ptr<tsl::elm::ListItem> listItem;
         size_t pos;
@@ -2077,11 +2114,16 @@ public:
         //bool toggleStateOn;
 
         if (selectedItemsList.empty()) {
-            if (commandGrouping != DEFAULT_STR)
-                addHeader(list, removeTag(specificKey.substr(1)));
+            if (commandGrouping != DEFAULT_STR) {
+                std::string cleanSpecificKey = specificKey.substr(1);
+                removeTag(cleanSpecificKey);
+                addHeader(list, cleanSpecificKey);
+            }
             listItem = std::make_unique<tsl::elm::ListItem>(EMPTY);
             list->addItem(listItem.release());
         }
+
+        std::string tmpSelectedItem;
 
         for (size_t i = 0; i < selectedItemsList.size(); ++i) {
             const std::string& selectedItem = selectedItemsList[i];
@@ -2090,19 +2132,23 @@ public:
             if (itemName.front() == '.') // Skip hidden items
                 continue;
 
-            if (!isDirectory(preprocessPath(selectedItem, filePath)))
-                itemName = dropExtension(itemName);
+            tmpSelectedItem = selectedItem;
+            preprocessPath(tmpSelectedItem, filePath);
+            if (!isDirectory(tmpSelectedItem))
+                dropExtension(itemName);
 
             if (sourceType == FILE_STR) {
                 if (commandGrouping == "split") {
-                    groupingName = removeQuotes(getParentDirNameFromPath(selectedItem));
+                    groupingName = getParentDirNameFromPath(selectedItem);
+                    removeQuotes(groupingName);
 
                     if (lastGroupingName.empty() || (lastGroupingName != groupingName)) {
                         addHeader(list, groupingName);
                         lastGroupingName = groupingName;
                     }
                 } else if (commandGrouping == "split2") {
-                    groupingName = removeQuotes(getParentDirNameFromPath(selectedItem));
+                    groupingName = getParentDirNameFromPath(selectedItem);
+                    removeQuotes(groupingName);
 
                     pos = groupingName.find(" - ");
                     if (pos != std::string::npos) {
@@ -2115,7 +2161,8 @@ public:
                         lastGroupingName = groupingName;
                     }
                 } else if (commandGrouping == "split3") {
-                    groupingName = removeQuotes(getNameFromPath(selectedItem));
+                    groupingName = getNameFromPath(selectedItem);
+                    removeQuotes(groupingName);
 
                     pos = groupingName.find(" - ");
                     if (pos != std::string::npos) {
@@ -2128,9 +2175,14 @@ public:
                         lastGroupingName = groupingName;
                     }
                 } else if (commandGrouping == "split4") {
-                    groupingName = removeQuotes(getParentDirNameFromPath(selectedItem, 2));
-                    itemName = trim(removeQuotes(dropExtension(getNameFromPath(selectedItem))));
-                    footer = removeQuotes(getParentDirNameFromPath(selectedItem));
+                    groupingName = getParentDirNameFromPath(selectedItem, 2);
+                    removeQuotes(groupingName);
+                    itemName = getNameFromPath(selectedItem);
+                    dropExtension(itemName);
+                    removeQuotes(itemName);
+                    trim(itemName);
+                    footer = getParentDirNameFromPath(selectedItem);
+                    removeQuotes(footer);
 
                     if (lastGroupingName.empty() || (lastGroupingName != groupingName)) {
                         addHeader(list, groupingName);
@@ -2160,7 +2212,8 @@ public:
                         itemName = selectedItem.substr(0, pos);
                     }
                 } else if (commandGrouping == "split2") {
-                    footer = dropExtension(getNameFromPath(selectedItem));
+                    footer = getNameFromPath(selectedItem);
+                    dropExtension(footer);
                 }
 
                 listItem = std::make_unique<tsl::elm::ListItem>(itemName);
@@ -2520,6 +2573,9 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
     std::vector<std::string> entryList;
 
     std::string commandNameLower;
+
+    std::string cleanOptionName;
+
     for (size_t i = 0; i < options.size(); ++i) {
         auto& option = options[i];
         
@@ -2568,11 +2624,16 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
             if (!dropdownSection.empty()) {
                 if (i == 0) {
                     // Add a section break with small text to indicate the "Commands" section
-                    addHeader(list, removeTag(dropdownSection.substr(1)));
+                    std::string headerTitle = dropdownSection.substr(1);
+                    removeTag(headerTitle);
+
+                    addHeader(list, headerTitle);
                     skipSection = true;
                     lastSection = dropdownSection;
                 }
-                if (removeTag(optionName) == PACKAGE_INFO || removeTag(optionName) == "Package Info") {
+                cleanOptionName = optionName;
+                removeTag(cleanOptionName);
+                if (cleanOptionName == PACKAGE_INFO || cleanOptionName == "Package Info") {
                     if (!skipSection) {
                         lastSection = optionName;
                         addPackageInfo(list, packageHeader);
@@ -2607,12 +2668,16 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                         // override loading of the command footer
                         if (!commandFooter.empty() && commandFooter != NULL_STR){
                             footer = commandFooter;
-                            listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)));
+                            cleanOptionName = optionName.substr(1);
+                            removeTag(cleanOptionName);
+                            listItem = std::make_unique<tsl::elm::ListItem>(cleanOptionName);
                             listItem->setValue(footer);
                         } else {
                             footer = DROPDOWN_SYMBOL;
+                            cleanOptionName = optionName.substr(1);
+                            removeTag(cleanOptionName);
                             // Create reference to PackageMenu with dropdownSection set to optionName
-                            listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName.substr(1)), footer);
+                            listItem = std::make_unique<tsl::elm::ListItem>(cleanOptionName, footer);
                         }
                         
                         if (packageMenuMode)
@@ -2659,8 +2724,9 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                         skipSection = true;
                     } else {
                         if (optionName != lastSection) {
-                            
-                            if (removeTag(optionName) == PACKAGE_INFO || removeTag(optionName) == "Package Info") {
+                            cleanOptionName = optionName;
+                            removeTag(cleanOptionName);
+                            if (cleanOptionName == PACKAGE_INFO || cleanOptionName == "Package Info") {
                                 //logMessage("pre-before adding app info");
                                 if (!skipSection) {
                                     lastSection = optionName;
@@ -2670,7 +2736,7 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                                 }
                             } else {
                                 // Add a section break with small text to indicate the "Commands" section
-                                addHeader(list, removeTag(optionName));
+                                addHeader(list, cleanOptionName);
                                 lastSection = optionName;
                             }
                         }
@@ -2782,7 +2848,8 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                         maxValue = std::stoi(commandName.substr(MAX_VALUE_PATTERN.length()));
                         continue;
                     } else if (commandName.find(UNITS_PATTERN) == 0) {
-                        units = removeQuotes(commandName.substr(UNITS_PATTERN.length()));
+                        units = commandName.substr(UNITS_PATTERN.length());
+                        removeQuotes(units);
                         continue;
                     } else if (commandName.find(STEPS_PATTERN) == 0) {
                         steps = std::stoi(commandName.substr(STEPS_PATTERN.length()));
@@ -2822,17 +2889,21 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                     if (cmd.size() > 1) {
                         if (commandName == "file_source") {
                             if (currentSection == GLOBAL_STR) {
-                                pathPattern = preprocessPath(cmd[1], packagePath);
+                                pathPattern = cmd[1];
+                                preprocessPath(pathPattern, packagePath);
                                 sourceType = FILE_STR;
                             } else if (currentSection == ON_STR) {
-                                pathPatternOn = preprocessPath(cmd[1], packagePath);
+                                pathPatternOn = cmd[1];
+                                preprocessPath(pathPatternOn, packagePath);
                                 sourceTypeOn = FILE_STR;
                             } else if (currentSection == OFF_STR) {
-                                pathPatternOff = preprocessPath(cmd[1], packagePath);
+                                pathPatternOff = cmd[1];
+                                preprocessPath(pathPatternOff, packagePath);
                                 sourceTypeOff = FILE_STR;
                             }
                         } else if (commandName == "package_source") {
-                            packageSource = preprocessPath(cmd[1], packagePath);
+                            packageSource = cmd[1];
+                            preprocessPath(packageSource, packagePath);
                         }
                     }
                 }
@@ -2940,33 +3011,40 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                     
                         if (cmd.size() > 1) {
                             if (cmd[0] == "list_source") {
-                                //std::string listString = removeQuotes(cmd[1]);
-                                entryList = stringToList(removeQuotes(cmd[1]));
+                                std::string listString = cmd[1];
+                                removeQuotes(listString);
+                                entryList = stringToList(listString);
                                 break;
                             }
                             else if (cmd[0] == "list_file_source") {
-                                //std::string listPath = preprocessPath(cmd[1], packagePath);
-                                entryList = readListFromFile(preprocessPath(cmd[1], packagePath));
+                                std::string listPath = cmd[1];
+                                preprocessPath(listPath, packagePath);
+                                entryList = readListFromFile(listPath);
                                 break;
                             }
                             else if (cmd[0] == "ini_file_source") {
-                                //std::string iniPath = preprocessPath(cmd[1], packagePath);
-                                entryList = parseSectionsFromIni(preprocessPath(cmd[1], packagePath));
+                                std::string iniPath = cmd[1];
+                                preprocessPath(iniPath, packagePath);
+                                entryList = parseSectionsFromIni(iniPath);
                                 break;
                             }
                         }
                     
                         if (cmd.size() > 2) {
                             if (cmd[0] == "json_source") {
-                                //std::string jsonString = removeQuotes(cmd[1]);
-                                //std::string jsonKey = removeQuotes(cmd[2]);
-                                populateSelectedItemsList(JSON_STR, removeQuotes(cmd[1]), removeQuotes(cmd[2]), entryList);
+                                std::string jsonString = cmd[1];
+                                removeQuotes(jsonString);
+                                std::string jsonKey = cmd[2];
+                                removeQuotes(jsonKey);
+                                populateSelectedItemsList(JSON_STR, jsonString, jsonKey, entryList);
                                 break;
                             }
                             else if (cmd[0] == "json_file_source") {
-                                //std::string jsonPath = preprocessPath(cmd[1], packagePath);
-                                //std::string jsonKey = removeQuotes(cmd[2]);
-                                populateSelectedItemsList(JSON_FILE_STR, preprocessPath(cmd[1], packagePath), removeQuotes(cmd[2]), entryList);
+                                std::string jsonPath = cmd[1];
+                                preprocessPath(jsonPath, packagePath);
+                                std::string jsonKey = cmd[2];
+                                removeQuotes(jsonKey);
+                                populateSelectedItemsList(JSON_FILE_STR, jsonPath, jsonKey, entryList);
                                 break;
                             }
                         }
@@ -2981,10 +3059,14 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                     if ((footer == DROPDOWN_SYMBOL) || (footer.empty()) || footer == commandFooter) {
                         //if (!commandFooter.empty())
                         //    footer = commandFooter;
-                        listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName), footer);
+                        cleanOptionName = optionName;
+                        removeTag(cleanOptionName);
+                        listItem = std::make_unique<tsl::elm::ListItem>(cleanOptionName, footer);
                     }
                     else {
-                        listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName));
+                        cleanOptionName = optionName;
+                        removeTag(cleanOptionName);
+                        listItem = std::make_unique<tsl::elm::ListItem>(cleanOptionName);
 
                         if (commandMode == OPTION_STR)
                             listItem->setValue(footer);
@@ -3095,11 +3177,15 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                     
                     // For entries that are paths
                     itemName = getNameFromPath(selectedItem);
-                    if (!isDirectory(preprocessPath(selectedItem, packagePath)))
-                        itemName = dropExtension(itemName);
+                    std::string tmpSelectedItem = selectedItem;
+                    preprocessPath(tmpSelectedItem, packagePath);
+                    if (!isDirectory(tmpSelectedItem))
+                        dropExtension(itemName);
                     parentDirName = getParentDirNameFromPath(selectedItem);
                     if (commandMode == DEFAULT_STR  || commandMode == SLOT_STR || commandMode == OPTION_STR) { // for handiling toggles
-                        listItem = std::make_unique<tsl::elm::ListItem>(removeTag(optionName));
+                        cleanOptionName = optionName;
+                        removeTag(cleanOptionName);
+                        listItem = std::make_unique<tsl::elm::ListItem>(cleanOptionName);
                         if (commandMode == DEFAULT_STR)
                             listItem->setValue(footer, true);
                         else
@@ -3147,12 +3233,18 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                         });
                         list->addItem(listItem.release());
                     } else if (commandMode == TOGGLE_STR) {
-                        
-                        toggleListItem = std::make_unique<tsl::elm::ToggleListItem>(removeTag(optionName), false, ON, OFF);
-                        
+                        cleanOptionName = optionName;
+                        removeTag(cleanOptionName);
+                        toggleListItem = std::make_unique<tsl::elm::ToggleListItem>(cleanOptionName, false, ON, OFF);
+                        // Preprocess pathPatternOn and pathPatternOff separately
+                        preprocessPath(pathPatternOn, packagePath);
+                        preprocessPath(pathPatternOff, packagePath);
+
                         // Set the initial state of the toggle item
-                        if (!pathPatternOn.empty())
-                            toggleStateOn = isFileOrDirectory(preprocessPath(pathPatternOn, packagePath));
+                        if (!pathPatternOn.empty()){
+                            //preprocessPath(pathPatternOn, packagePath);
+                            toggleStateOn = isFileOrDirectory(pathPatternOn);
+                        }
                         else {
                             if ((footer != CAPITAL_ON_STR && footer != CAPITAL_OFF_STR) && !defaultToggleState.empty()) {
                                 if (defaultToggleState == ON_STR)
@@ -3164,14 +3256,19 @@ void drawCommandsMenu(std::unique_ptr<tsl::elm::List>& list,
                             toggleStateOn = (footer == CAPITAL_ON_STR);
                         }
                         
+
                         toggleListItem->setState(toggleStateOn);
                         
                         toggleListItem->setStateChangedListener([i, commandsOn, commandsOff, keyName = option.first, packagePath,
                             pathPatternOn, pathPatternOff, listItemRaw = toggleListItem.get()](bool state) {
                             
                             tsl::Overlay::get()->getCurrentGui()->requestFocus(listItemRaw, tsl::FocusDirection::None);
-                            interpretAndExecuteCommands(state ? getSourceReplacement(commandsOn, preprocessPath(pathPatternOn, packagePath), i, packagePath) :
-                                getSourceReplacement(commandsOff, preprocessPath(pathPatternOff, packagePath), i, packagePath), packagePath, keyName);
+                            
+                            // Now pass the preprocessed paths to getSourceReplacement
+                            interpretAndExecuteCommands(state ? getSourceReplacement(commandsOn, pathPatternOn, i, packagePath) :
+                                getSourceReplacement(commandsOff, pathPatternOff, i, packagePath), packagePath, keyName);
+                            
+                            // Set the ini file value after executing the command
                             setIniFileValue((packagePath + CONFIG_FILENAME), keyName, FOOTER_STR, state ? CAPITAL_ON_STR : CAPITAL_OFF_STR);
                             
                         });
@@ -3728,6 +3825,7 @@ public:
                 setDefaultValue(ultrahandSection, "hide_package_versions", FALSE_STR, hidePackageVersions);
                 setDefaultValue(ultrahandSection, "memory_expansion", FALSE_STR, useMemoryExpansion);
                 // setDefaultValue(ultrahandSection, "custom_wallpaper", FALSE_STR, useCustomWallpaper);
+                setDefaultValue(ultrahandSection, "swipe_to_open", TRUE_STR, useSwipeToOpen);
                 setDefaultValue(ultrahandSection, "right_alignment", FALSE_STR, useRightAlignment);
                 setDefaultValue(ultrahandSection, "opaque_screenshots", TRUE_STR, useOpaqueScreenshots);
                 setDefaultValue(ultrahandSection, "progress_animation", FALSE_STR, progressAnimation);
@@ -3757,7 +3855,8 @@ public:
             
                 // Handle the 'to_packages' option if it exists
                 if (ultrahandSection.count("to_packages") > 0) {
-                    toPackages = (trim(ultrahandSection["to_packages"]) == TRUE_STR);
+                    trim(ultrahandSection["to_packages"]);
+                    toPackages = (ultrahandSection["to_packages"] == TRUE_STR);
                 }
             
                 // Mark settings as loaded if the "in_overlay" setting exists
@@ -4008,7 +4107,8 @@ public:
                                 
                                 
                                 std::string useOverlayLaunchArgs = parseValueFromIniSection(OVERLAYS_INI_FILEPATH, overlayFileName, USE_LAUNCH_ARGS_STR);
-                                std::string overlayLaunchArgs = removeQuotes(parseValueFromIniSection(OVERLAYS_INI_FILEPATH, overlayFileName, LAUNCH_ARGS_STR));
+                                std::string overlayLaunchArgs = parseValueFromIniSection(OVERLAYS_INI_FILEPATH, overlayFileName, LAUNCH_ARGS_STR);
+                                removeQuotes(overlayLaunchArgs);
                                 
                                 if (inHiddenMode) {
                                     setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, IN_HIDDEN_OVERLAY_STR, TRUE_STR);
@@ -4180,8 +4280,10 @@ public:
 
                         packageHeader = getPackageHeaderFromIni(PACKAGE_PATH + packageName+ "/" +PACKAGE_FILENAME);
                         
-                        if (cleanVersionLabels)
-                            packageHeader.version = removeQuotes(cleanVersionLabel(packageHeader.version));
+                        if (cleanVersionLabels) {
+                            packageHeader.version = cleanVersionLabel(packageHeader.version);
+                            removeQuotes(packageHeader.version);
+                        }
                         
                         //packageHeader.clear(); // free memory
 

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -1591,6 +1591,8 @@ void applyPlaceholderReplacements(std::vector<std::string>& cmd, const std::stri
     //    }
     //}
 
+    std::string titleId = getTitleIdAsString();
+
     for (auto& arg : cmd) {
         replaceAllPlaceholders(arg, "{ram_vendor}", memoryVendor);
         replaceAllPlaceholders(arg, "{ram_model}", memoryModel);
@@ -1602,6 +1604,7 @@ void applyPlaceholderReplacements(std::vector<std::string>& cmd, const std::stri
         replaceAllPlaceholders(arg, "{gpu_iddq}", std::to_string(gpuIDDQ));
         replaceAllPlaceholders(arg, "{soc_speedo}", std::to_string(socSpeedo0));
         replaceAllPlaceholders(arg, "{soc_iddq}", std::to_string(socIDDQ));
+        replaceAllPlaceholders(arg, "{title_id}", titleId);
         for (const auto& [placeholder, replacer] : placeholders) {
             replacePlaceholders(arg, placeholder, replacer);
         }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -2227,7 +2227,7 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
                     if (!commandSuccess) resetCommandSuccess = true;
             
                     interpretAndExecuteCommands(std::move(bootCommands), packagePath, bootCommandName);
-            
+                    resetPercentages();
                     if (resetCommandSuccess) {
                         commandSuccess = false;
                     }
@@ -2357,6 +2357,7 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
 
 void executeCommands(std::vector<std::vector<std::string>> commands) {
     interpretAndExecuteCommands(std::move(commands), "", "");
+    resetPercentages();
 }
 
 

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -35,6 +35,7 @@
 static std::atomic<bool> abortCommand(false);
 static std::atomic<bool> triggerExit(false);
 
+static bool exitingUltrahand = false;
 
 bool isDownloadCommand = false;
 bool commandSuccess = false;
@@ -2314,6 +2315,7 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
                 setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, IN_OVERLAY_STR, TRUE_STR); // this is handled within tesla.hpp
             }
         }
+        exitingUltrahand = true;
         //setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, IN_OVERLAY_STR, TRUE_STR); // this is handled within tesla.hpp
         tsl::setNextOverlay(OVERLAY_PATH+"ovlmenu.ovl");
         tsl::Overlay::get()->close();
@@ -2363,6 +2365,15 @@ void executeCommands(std::vector<std::vector<std::string>> commands) {
     resetPercentages();
 }
 
+void executeIniCommands(const std::string &iniPath, const std::string &section) {
+    if (isFileOrDirectory(iniPath)) {
+        auto commands = loadSpecificSectionFromIni(iniPath, section);
+        if (!commands.empty()) {
+            interpretAndExecuteCommands(std::move(commands), PACKAGE_PATH, section);
+            resetPercentages();
+        }
+    }
+}
 
 
 // Thread information structure

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -809,11 +809,13 @@ void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std
 
             if (commandName == LIST_STR) {
                 if (cmdSize >= 2) {
-                    listString = removeQuotes(cmd[1]);
+                    listString = cmd[1];
+                    removeQuotes(listString);
                 }
             } else if (commandName == LIST_FILE_STR) {
                 if (cmdSize >= 2) {
-                    listPath = preprocessPath(cmd[1], packagePath);
+                    listPath = cmd[1];
+                    preprocessPath(listPath, packagePath);
                 }
             } else if (commandName == JSON_STR) {
                 if (cmdSize >= 2) {
@@ -821,15 +823,18 @@ void addTable(std::unique_ptr<tsl::elm::List>& list, std::vector<std::vector<std
                 }
             } else if (commandName == JSON_FILE_STR) {
                 if (cmdSize >= 2) {
-                    jsonPath = preprocessPath(cmd[1], packagePath);
+                    jsonPath = cmd[1];
+                    preprocessPath(jsonPath, packagePath);
                 }
             } else if (commandName == INI_FILE_STR) {
                 if (cmdSize >= 2) {
-                    iniPath = preprocessPath(cmd[1], packagePath);
+                    iniPath = cmd[1];
+                    preprocessPath(iniPath, packagePath);
                 }
             } else if (commandName == HEX_FILE_STR) {
                 if (cmdSize >= 2) {
-                    hexPath = preprocessPath(cmd[1], packagePath);
+                    hexPath = cmd[1];
+                    preprocessPath(hexPath, packagePath);
                 }
             } else {
                 sectionLines.push_back(cmd[0]);
@@ -1149,12 +1154,16 @@ void applyReplaceIniPlaceholder(std::string& arg, const std::string& commandName
     //std::string replacement = arg;  // Copy arg because we need to modify it
 
     std::string placeholderContent = arg.substr(startPos + searchString.length(), endPos - startPos - searchString.length());
-    placeholderContent = trim(placeholderContent);
+    trim(placeholderContent);
 
     size_t commaPos = placeholderContent.find(',');
     if (commaPos != std::string::npos) {
-        std::string iniSection = removeQuotes(trim(placeholderContent.substr(0, commaPos)));
-        std::string iniKey = removeQuotes(trim(placeholderContent.substr(commaPos + 1)));
+        std::string iniSection = placeholderContent.substr(0, commaPos);
+        trim(iniSection);
+        removeQuotes(iniSection);
+        std::string iniKey = placeholderContent.substr(commaPos + 1);
+        trim(iniKey);
+        removeQuotes(iniKey);
 
         std::string parsedResult = parseValueFromIniSection(iniPath, iniSection, iniKey);
         // Replace the placeholder with the parsed result and keep the remaining string intact
@@ -1286,12 +1295,17 @@ std::vector<std::vector<std::string>> getSourceReplacement(const std::vector<std
     std::string listString, listPath, jsonString, jsonPath, iniPath;
     bool usingFileSource = false;
 
-    std::string fileName = (isDirectory(entry) ? getNameFromPath(entry) : dropExtension(getNameFromPath(entry)));
+    std::string fileName = getNameFromPath(entry);
+    if (!isDirectory(entry))
+        dropExtension(fileName);
+
     std::vector<std::string> modifiedCmd;
     std::string commandName;
     std::string modifiedArg;
     size_t startPos, endPos;
     std::string replacement;
+
+    std::string path;
 
     for (const auto& cmd : commands) {
         if (cmd.empty())
@@ -1321,20 +1335,32 @@ std::vector<std::vector<std::string>> getSourceReplacement(const std::vector<std
                 if (commandName == "file_source") {
                     usingFileSource = true;
                 }
-                else if (commandName == "list_source" && listString.empty())
-                    listString = removeQuotes(cmd[1]);
-                else if (commandName == "list_file_source" && listPath.empty())
-                    listPath = preprocessPath(cmd[1], packagePath);
-                else if (commandName == "ini_file_source" && iniPath.empty())
-                    iniPath = preprocessPath(cmd[1], packagePath);
-                else if (commandName == "json_source" && jsonString.empty())
+                else if (commandName == "list_source" && listString.empty()) {
+                    listString = cmd[1];
+                    removeQuotes(listString);
+                }
+                else if (commandName == "list_file_source" && listPath.empty()) {
+                    listPath = cmd[1];
+                    preprocessPath(listPath, packagePath);
+                }
+                else if (commandName == "ini_file_source" && iniPath.empty()) {
+                    iniPath = cmd[1];
+                    preprocessPath(iniPath, packagePath);
+                }
+                else if (commandName == "json_source" && jsonString.empty()) {
                     jsonString = cmd[1];
-                else if (commandName == "json_file_source" && jsonPath.empty())
-                    jsonPath = preprocessPath(cmd[1], packagePath);
+                }
+                else if (commandName == "json_file_source" && jsonPath.empty()) {
+                    jsonPath = cmd[1];
+                    preprocessPath(jsonPath, packagePath);
+                }
                 
                 replaceAllPlaceholders(modifiedArg, "{file_source}", entry);
                 replaceAllPlaceholders(modifiedArg, "{file_name}", fileName);
-                replaceAllPlaceholders(modifiedArg, "{folder_name}", removeQuotes(getParentDirNameFromPath(entry)));
+                path = getParentDirNameFromPath(entry);
+                removeQuotes(path);
+
+                replaceAllPlaceholders(modifiedArg, "{folder_name}", path);
 
                 if (modifiedArg.find("{list_source(") != std::string::npos) {
                     //modifiedArg = replacePlaceholder(modifiedArg, "*", std::to_string(entryIndex));
@@ -1489,7 +1515,8 @@ void applyPlaceholderReplacements(std::vector<std::string>& cmd, const std::stri
             size_t startPos = placeholder.find("(") + 1;
             size_t endPos = placeholder.find(")");
             std::string format = (endPos != std::string::npos) ? placeholder.substr(startPos, endPos - startPos) : "%Y-%m-%d %H:%M:%S";
-            return getCurrentTimestamp(removeQuotes(format));
+            removeQuotes(format);
+            return getCurrentTimestamp(format);
         }},
         {"{decimal_to_hex(", [&](const std::string& placeholder) {
             size_t startPos = placeholder.find("(") + 1;
@@ -1541,10 +1568,14 @@ void applyPlaceholderReplacements(std::vector<std::string>& cmd, const std::stri
                 std::string str = parameters.substr(0, firstCommaPos);
                 std::string delimiter = parameters.substr(firstCommaPos + 1, lastCommaPos - firstCommaPos - 1);
                 size_t index = std::stoi(parameters.substr(lastCommaPos + 1));
-        
-                std::string result = splitStringAtIndex(removeQuotes(trim(str)), removeQuotes(trim(delimiter)), index);
+                trim(str);
+                removeQuotes(str);
+                trim(delimiter);
+                removeQuotes(delimiter);
+
+                std::string result = splitStringAtIndex(str, delimiter, index);
                 if (result.empty()) {
-                    return removeQuotes(trim(str));
+                    return str;
                 } else {
                     return result;
                 }
@@ -1705,11 +1736,13 @@ void interpretAndExecuteCommands(std::vector<std::vector<std::string>>&& command
 
                 if (commandName == LIST_STR) {
                     if (cmdSize >= 2) {
-                        listString = removeQuotes(cmd[1]);
+                        listString = cmd[1];
+                        removeQuotes(listString);
                     }
                 } else if (commandName == LIST_FILE_STR) {
                     if (cmdSize >= 2) {
-                        listPath = preprocessPath(cmd[1], packagePath);
+                        listPath = cmd[1];
+                        preprocessPath(listPath, packagePath);
                     }
                 } else if (commandName == JSON_STR) {
                     if (cmdSize >= 2) {
@@ -1717,15 +1750,18 @@ void interpretAndExecuteCommands(std::vector<std::vector<std::string>>&& command
                     }
                 } else if (commandName == JSON_FILE_STR) {
                     if (cmdSize >= 2) {
-                        jsonPath = preprocessPath(cmd[1], packagePath);
+                        jsonPath = cmd[1];
+                        preprocessPath(jsonPath, packagePath);
                     }
                 } else if (commandName == INI_FILE_STR) {
                     if (cmdSize >= 2) {
-                        iniPath = preprocessPath(cmd[1], packagePath);
+                        iniPath = cmd[1];
+                        preprocessPath(iniPath, packagePath);
                     }
                 } else if (commandName == HEX_FILE_STR) {
                     if (cmdSize >= 2) {
-                        hexPath = preprocessPath(cmd[1], packagePath);
+                        hexPath = cmd[1];
+                        preprocessPath(hexPath, packagePath);
                     }
                 } else {
                     processCommand(cmd, packagePath, selectedCommand);
@@ -1744,21 +1780,29 @@ void interpretAndExecuteCommands(std::vector<std::vector<std::string>>&& command
 void parseCommandArguments(const std::vector<std::string>& cmd, const std::string& packagePath, std::string& sourceListPath, std::string& destinationListPath, std::string& logSource, std::string& logDestination, std::string& sourcePath, std::string& destinationPath, std::string& copyFilterListPath, std::string& filterListPath) {
     for (size_t i = 1; i < cmd.size(); ++i) {
         if (cmd[i] == "-src" && i + 1 < cmd.size()) {
-            sourceListPath = preprocessPath(cmd[++i], packagePath);
+            sourceListPath = cmd[++i];
+            preprocessPath(sourceListPath, packagePath);
         } else if (cmd[i] == "-dest" && i + 1 < cmd.size()) {
-            destinationListPath = preprocessPath(cmd[++i], packagePath);
+            destinationListPath = cmd[++i];
+            preprocessPath(destinationListPath, packagePath);
         } else if (cmd[i] == "-log_src" && i + 1 < cmd.size()) {
-            logSource = preprocessPath(cmd[++i], packagePath);
+            logSource = cmd[++i];
+            preprocessPath(logSource, packagePath);
         } else if (cmd[i] == "-log_dest" && i + 1 < cmd.size()) {
-            logDestination = preprocessPath(cmd[++i], packagePath);
+            logDestination = cmd[++i];
+            preprocessPath(logDestination, packagePath);
         } else if ((cmd[i] == "-copy_filter" || cmd[i] == "-cp_filter") && i + 1 < cmd.size()) {
-            copyFilterListPath = preprocessPath(cmd[++i], packagePath);
+            copyFilterListPath = cmd[++i];
+            preprocessPath(copyFilterListPath, packagePath);
         } else if (cmd[i] == "-filter" && i + 1 < cmd.size()) {
-            filterListPath = preprocessPath(cmd[++i], packagePath);
+            filterListPath = cmd[++i];
+            preprocessPath(filterListPath, packagePath);
         } else if (sourcePath.empty()) {
-            sourcePath = preprocessPath(cmd[i], packagePath);
+            sourcePath = cmd[i];
+            preprocessPath(sourcePath, packagePath);
         } else if (destinationPath.empty()) {
-            destinationPath = preprocessPath(cmd[i], packagePath);
+            destinationPath = cmd[i];
+            preprocessPath(destinationPath, packagePath);
         }
     }
 }
@@ -1766,7 +1810,8 @@ void parseCommandArguments(const std::vector<std::string>& cmd, const std::strin
 
 void handleMakeDirCommand(const std::vector<std::string>& cmd, const std::string& packagePath) {
     if (cmd.size() >= 2) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
         createDirectory(sourcePath);
     }
 }
@@ -1786,8 +1831,10 @@ void handleCopyCommand(const std::vector<std::string>& cmd, const std::string& p
 
         
         for (size_t i = 0; i < sourceFilesList.size(); ++i) {
-            sourcePath = preprocessPath(sourceFilesList[i]);
-            destinationPath = preprocessPath(destinationFilesList[i]);
+            sourcePath = sourceFilesList[i];
+            preprocessPath(sourcePath, packagePath);
+            destinationPath = destinationFilesList[i];
+            preprocessPath(destinationPath, packagePath);
             if (filterListPath.empty() || (!filterListPath.empty() && filterSet.find(sourcePath) == filterSet.end())) {
                 totalBytesCopied = 0;
                 totalSize = getTotalSize(sourcePath);  // Ensure this is calculated if needed.
@@ -1826,7 +1873,8 @@ void handleDeleteCommand(const std::vector<std::string>& cmd, const std::string&
             filterSet = readSetFromFile(filterListPath);
 
         for (size_t i = 0; i < sourceFilesList.size(); ++i) {
-            sourcePath = preprocessPath(sourceFilesList[i]);
+            sourcePath = sourceFilesList[i];
+            preprocessPath(sourcePath, packagePath);
             if (filterListPath.empty() || (!filterListPath.empty() && filterSet.find(sourcePath) == filterSet.end()))
                 deleteFileOrDirectory(sourcePath);
         }
@@ -1850,8 +1898,15 @@ void handleDeleteCommand(const std::vector<std::string>& cmd, const std::string&
 
 void handleMirrorCommand(const std::vector<std::string>& cmd, const std::string& packagePath) {
     if (cmd.size() >= 2) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string destinationPath = cmd.size() >= 3 ? preprocessPath(cmd[2], packagePath) : ROOT_PATH;
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string destinationPath;
+        if (cmd.size() >= 3) {
+            destinationPath = cmd[2];   // Extract the path first
+            preprocessPath(destinationPath, packagePath);  // Preprocess it
+        } else {
+            destinationPath = ROOT_PATH;  // Default value if cmd.size() < 3
+        }
         std::string operation = (cmd[0] == "mirror_copy" || cmd[0] == "mirror_cp") ? "copy" : "delete";
 
         if (sourcePath.find('*') == std::string::npos) {
@@ -1886,8 +1941,10 @@ void handleMoveCommand(const std::vector<std::string>& cmd, const std::string& p
                 filterSet = readSetFromFile(filterListPath);
 
             for (size_t i = 0; i < sourceFilesList.size(); ++i) {
-                sourcePath = preprocessPath(sourceFilesList[i]);
-                destinationPath = preprocessPath(destinationFilesList[i]);
+                sourcePath = sourceFilesList[i];
+                preprocessPath(sourcePath, packagePath);
+                destinationPath = destinationFilesList[i];
+                preprocessPath(destinationPath, packagePath);
                 if (filterListPath.empty() || (!filterListPath.empty() && filterSet.find(sourcePath) == filterSet.end())) {
                     if (!copyFilterListPath.empty() && copyFilterSet.find(sourcePath) != copyFilterSet.end()) {
                         totalBytesCopied = 0;
@@ -1917,37 +1974,57 @@ void handleMoveCommand(const std::vector<std::string>& cmd, const std::string& p
 
 void handleIniCommands(const std::vector<std::string>& cmd, const std::string& packagePath) {
     if (cmd[0] == "add-ini-section" && cmd.size() >= 2) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
         addIniSection(sourcePath, desiredSection);
     } else if (cmd[0] == "rename-ini-section" && cmd.size() >= 3) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
-        std::string desiredNewSection = removeQuotes(cmd[3]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
+        std::string desiredNewSection = cmd[3];
+        removeQuotes(desiredNewSection);
         renameIniSection(sourcePath, desiredSection, desiredNewSection);
     } else if (cmd[0] == "remove-ini-section" && cmd.size() >= 2) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
         removeIniSection(sourcePath, desiredSection);
     } else if (cmd[0] == "remove-ini-key" && cmd.size() >= 3) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
-        std::string desiredKey = removeQuotes(cmd[3]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
+        std::string desiredKey = cmd[3];
+        removeQuotes(desiredKey);
         removeIniKey(sourcePath, desiredSection, desiredKey);
     } else if ((cmd[0] == "set-ini-val" || cmd[0] == "set-ini-value") && cmd.size() >= 5) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
-        std::string desiredKey = removeQuotes(cmd[3]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
+        std::string desiredKey = cmd[3];
+        removeQuotes(desiredKey);
         std::string desiredValue = std::accumulate(cmd.begin() + 4, cmd.end(), std::string(""), [](const std::string& a, const std::string& b) -> std::string {
-            return removeQuotes(a.empty() ? b : a + " " + b);
+            std::string returnStr = (a.empty() ? b : a + " " + b);
+            removeQuotes(returnStr);
+            return returnStr;
         });
         setIniFileValue(sourcePath, desiredSection, desiredKey, desiredValue);
     } else if (cmd[0] == "set-ini-key" && cmd.size() >= 5) {
-        std::string sourcePath = preprocessPath(cmd[1], packagePath);
-        std::string desiredSection = removeQuotes(cmd[2]);
-        std::string desiredKey = removeQuotes(cmd[3]);
+        std::string sourcePath = cmd[1];
+        preprocessPath(sourcePath, packagePath);
+        std::string desiredSection = cmd[2];
+        removeQuotes(desiredSection);
+        std::string desiredKey = cmd[3];
+        removeQuotes(desiredKey);
         std::string desiredNewKey = std::accumulate(cmd.begin() + 4, cmd.end(), std::string(""), [](const std::string& a, const std::string& b) -> std::string {
-            return removeQuotes(a.empty() ? b : a + " " + b);
+            std::string returnStr = (a.empty() ? b : a + " " + b);
+            removeQuotes(returnStr);
+            return returnStr;
         });
         setIniFileKey(sourcePath, desiredSection, desiredKey, desiredNewKey);
     }
@@ -1958,7 +2035,9 @@ void handleHexEdit(const std::string& sourcePath, const std::string& secondArg, 
         hexEditByOffset(sourcePath, secondArg, thirdArg);
     } else if (commandName == "hex-by-swap") {
         if (cmd.size() >= 5) {
-            size_t occurrence = std::stoul(removeQuotes(cmd[4]));
+            std::string selectedStr = cmd[4];
+            removeQuotes(selectedStr);
+            size_t occurrence = std::stoul(selectedStr);
             hexEditFindReplace(sourcePath, secondArg, thirdArg, occurrence);
         } else {
             hexEditFindReplace(sourcePath, secondArg, thirdArg);
@@ -1972,7 +2051,9 @@ void handleHexEdit(const std::string& sourcePath, const std::string& secondArg, 
             hexDataToReplace += std::string(hexDataReplacement.length() - hexDataToReplace.length(), '\0');
         }
         if (cmd.size() >= 5) {
-            size_t occurrence = std::stoul(removeQuotes(cmd[4]));
+            std::string selectedStr = cmd[4];
+            removeQuotes(selectedStr);
+            size_t occurrence = std::stoul(selectedStr);
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement, occurrence);
         } else {
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement);
@@ -1981,7 +2062,9 @@ void handleHexEdit(const std::string& sourcePath, const std::string& secondArg, 
         std::string hexDataToReplace = decimalToHex(secondArg);
         std::string hexDataReplacement = decimalToHex(thirdArg);
         if (cmd.size() >= 5) {
-            size_t occurrence = std::stoul(removeQuotes(cmd[4]));
+            std::string selectedStr = cmd[4];
+            removeQuotes(selectedStr);
+            size_t occurrence = std::stoul(selectedStr);
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement, occurrence);
         } else {
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement);
@@ -1990,7 +2073,9 @@ void handleHexEdit(const std::string& sourcePath, const std::string& secondArg, 
         std::string hexDataToReplace = decimalToReversedHex(secondArg);
         std::string hexDataReplacement = decimalToReversedHex(thirdArg);
         if (cmd.size() >= 5) {
-            size_t occurrence = std::stoul(removeQuotes(cmd[4]));
+            std::string selectedStr = cmd[4];
+            removeQuotes(selectedStr);
+            size_t occurrence = std::stoul(selectedStr);
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement, occurrence);
         } else {
             hexEditFindReplace(sourcePath, hexDataToReplace, hexDataReplacement);
@@ -2050,14 +2135,18 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         handleIniCommands(cmd, packagePath);
     } else if (commandName == "set-footer") {
         if (cmd.size() >= 2) {
-            std::string desiredValue = removeQuotes(cmd[1]);
+            std::string desiredValue = cmd[1];
+            removeQuotes(desiredValue);
             setIniFileValue((packagePath + CONFIG_FILENAME), selectedCommand, FOOTER_STR, desiredValue);
         }
     } else if (commandName == "compare") {
         if (cmd.size() >= 4) {
-            std::string path1 = preprocessPath(cmd[1], packagePath);
-            std::string path2 = preprocessPath(cmd[2], packagePath);
-            std::string outputPath = preprocessPath(cmd[3], packagePath);
+            std::string path1 = cmd[1];
+            preprocessPath(path1, packagePath);
+            std::string path2 = cmd[2];
+            preprocessPath(path2, packagePath);
+            std::string outputPath = cmd[3];
+            preprocessPath(outputPath, packagePath);
             if (path1.find('*') != std::string::npos)
                 compareWildcardFilesLists(path1, path2, outputPath);
             else
@@ -2065,15 +2154,21 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         }
     } else if (commandName.substr(0, 7) == "hex-by-") {
         if (cmd.size() >= 4) {
-            std::string sourcePath = preprocessPath(cmd[1], packagePath);
-            const std::string& secondArg = removeQuotes(cmd[2]);
-            const std::string& thirdArg = removeQuotes(cmd[3]);
+            std::string sourcePath = cmd[1];
+            preprocessPath(sourcePath, packagePath);
+            std::string secondArg = cmd[2];
+            removeQuotes(secondArg);
+            std::string thirdArg = cmd[3];
+            removeQuotes(thirdArg);
 
             if (commandName == "hex-by-custom-offset" || commandName == "hex-by-custom-decimal-offset" || commandName == "hex-by-custom-rdecimal-offset") {
                 if (cmd.size() >= 5) {
-                    std::string customPattern = removeQuotes(cmd[2]);
-                    std::string offset = removeQuotes(cmd[3]);
-                    std::string hexDataReplacement = removeQuotes(cmd[4]);
+                    std::string customPattern = cmd[2];
+                    removeQuotes(customPattern);
+                    std::string offset = cmd[3];
+                    removeQuotes(offset);
+                    std::string hexDataReplacement = cmd[4];
+                    removeQuotes(hexDataReplacement);
                     handleHexByCustom(sourcePath, customPattern, offset, hexDataReplacement, commandName);
                 }
             } else {
@@ -2082,8 +2177,10 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         }
     } else if (commandName == "download") {
         if (cmd.size() >= 3) {
-            std::string fileUrl = preprocessUrl(cmd[1]);
-            std::string destinationPath = preprocessPath(cmd[2], packagePath);
+            std::string fileUrl = cmd[1];
+            preprocessUrl(fileUrl);
+            std::string destinationPath = cmd[2];
+            preprocessPath(destinationPath, packagePath);
             bool downloadSuccess = false;
             for (size_t i = 0; i < 3; ++i) {
                 downloadSuccess = downloadFile(fileUrl, destinationPath);
@@ -2097,24 +2194,30 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         }
     } else if (commandName == "unzip") {
         if (cmd.size() >= 3) {
-            std::string sourcePath = preprocessPath(cmd[1], packagePath);
-            std::string destinationPath = preprocessPath(cmd[2], packagePath);
+            std::string sourcePath = cmd[1];
+            preprocessPath(sourcePath, packagePath);
+            std::string destinationPath = cmd[2];
+            preprocessPath(destinationPath, packagePath);
             commandSuccess = unzipFile(sourcePath, destinationPath) && commandSuccess;
         }
     } else if (commandName == "pchtxt2ips") {
         if (cmd.size() >= 3) {
-            std::string sourcePath = preprocessPath(cmd[1], packagePath);
-            std::string destinationPath = preprocessPath(cmd[2], packagePath);
+            std::string sourcePath = cmd[1];
+            preprocessPath(sourcePath, packagePath);
+            std::string destinationPath = cmd[2];
+            preprocessPath(destinationPath, packagePath);
             commandSuccess = pchtxt2ips(sourcePath, destinationPath) && commandSuccess;
         }
     } else if (commandName == "pchtxt2cheat") {
         if (cmd.size() >= 2) {
-            std::string sourcePath = preprocessPath(cmd[1], packagePath);
+            std::string sourcePath = cmd[1];
+            preprocessPath(sourcePath, packagePath);
             commandSuccess = pchtxt2cheat(sourcePath) && commandSuccess;
         }
     } else if (commandName == "exec") {
         if (cmd.size() >= 2) {
-            std::string bootCommandName = removeQuotes(cmd[1]);
+            std::string bootCommandName = cmd[1];
+            removeQuotes(bootCommandName);
             if (isFileOrDirectory(packagePath + BOOT_PACKAGE_FILENAME)) {
                 // Load only the commands from the specific section (bootCommandName)
                 auto bootCommands = loadSpecificSectionFromIni(packagePath + BOOT_PACKAGE_FILENAME, bootCommandName);
@@ -2138,9 +2241,11 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         if (util::IsErista() || util::SupportsMarikoRebootToConfig()) {
             std::string rebootOption;
             if (cmd.size() >= 2) {
-                rebootOption = removeQuotes(cmd[1]);
+                rebootOption = cmd[1];
+                removeQuotes(rebootOption);
                 if (cmd.size() >= 3) {
-                    std::string option = removeQuotes(cmd[2]);
+                    std::string option = cmd[2];
+                    removeQuotes(option);
                     if (rebootOption == "boot") {
                         Payload::HekateConfigList bootConfigList = Payload::LoadHekateConfigList();
                         rebootToHekateConfig(bootConfigList, option, false);
@@ -2177,7 +2282,8 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         spsmExit();
     } else if (commandName == "shutdown") {
         if (cmd.size() >= 2) {
-            std::string selection = removeQuotes(cmd[1]);
+            std::string selection = cmd[1];
+            removeQuotes(selection);
             if (selection == "controllers") {
                 powerOffAllControllers();
             }
@@ -2196,7 +2302,8 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
     } else if (commandName == "exit") {
         //triggerExit.store(true, std::memory_order_release);
         if (cmd.size() >= 2) {
-            std::string selection = removeQuotes(cmd[1]);
+            std::string selection = cmd[1];
+            removeQuotes(selection);
             if (selection == "overlays") {
                 setIniFileValue(ULTRAHAND_CONFIG_INI_PATH, ULTRAHAND_PROJECT_NAME, IN_OVERLAY_STR, TRUE_STR); // this is handled within tesla.hpp
             } else if (selection == "packages") {
@@ -2210,7 +2317,8 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         return;
     } else if (commandName == "backlight") {
         if (cmd.size() >= 2) {
-            std::string togglePattern = removeQuotes(cmd[1]);
+            std::string togglePattern = cmd[1];
+            removeQuotes(togglePattern);
             lblInitialize();
             if (togglePattern == ON_STR)
                 lblSwitchBacklightOn(0);
@@ -2225,7 +2333,8 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         if (cmd.size() == 1)
             refreshPage = true;
         else if (cmd.size() > 1) {
-            std::string refreshPattern = removeQuotes(cmd[1]);
+            std::string refreshPattern = cmd[1];
+            removeQuotes(refreshPattern);
             if (refreshPattern == "theme")
                 tsl::initializeThemeVars();
             else if (refreshPattern == "package")
@@ -2238,7 +2347,8 @@ void processCommand(const std::vector<std::string>& cmd, const std::string& pack
         interpreterLogging = true;
     } else if (commandName == "clear") {
         if (cmd.size() >= 2) {
-            std::string clearOption = removeQuotes(cmd[1]);
+            std::string clearOption = cmd[1];
+            removeQuotes(clearOption);
             if (clearOption == "log") deleteFileOrDirectory(defaultLogFilePath);
             else if (clearOption == "hex_sum_cache") hexSumCache.clear();
         }


### PR DESCRIPTION
List of changes:
1. Introduction of new `Swipe to Open` feature (an alternative to `Key Combo` for opening Ultrahand).
    - This feature is now on by default, but can be toggled off in `Settings > UI Settings > Miscellaneous > Effects > Swipe to Open`.
    - To trigger a swipe launch, swipe your finger from off the screen inwards ~1.5cm from the side where the menu is being drawn (left by default or right) in <200ms .
    - **Note:** It should be relatively hard to trigger by accident even if you play touch sensitive games, but still easy enough to launch any time you try.
2. Introduction of new placeholder variable `{title_id}` for returning the title ID of the currently running game / application.
    - Will return `null` if a game / application is not open.
    - This placeholder should allow some more complex packages to be made.
3. Root package folder `exit_package.ini` will now have command `exit` only ran when Ultrahand (and any other running overlay) is completely closed.
4. More bug fixes and code optimizations.
    - Clean-up of progress percentage implementation.
    - Reduction of string copying for various string functions.