### PR TITLE
fix zh-cn.json

### DIFF
--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -81,7 +81,7 @@
     "OVERLAY_VERSIONS": "插件版本显示",
     "PACKAGE_VERSIONS": "插件包版本显示",
     "LAUNCH_COMBOS": "启动组合键",
-    "OPAQUE_SCREENSHOTS": "不透明的截图”",
+    "OPAQUE_SCREENSHOTS": "不透明的截图",
     "PAGE_SWAP": "页面切换",
     "DYNAMIC_LOGO": "动态徽标",
     "ON": "开启",


### PR DESCRIPTION
Hello, I noticed a small error in zh-cn.json: there's an extra ”. Although it's not a issue, I think it would be good to fix it.
你好，我注意到zh-cn.json中有个小错误，多了一个 ”。虽然这并不是什么问题，但我觉得修复他是件好事。
![e2af8a412c96b43291536d2003d70b8e](https://github.com/user-attachments/assets/be57d4c1-d625-4983-9132-d52857dd29b1)
