### PR TITLE
Add new command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ARCH := -march=armv8-a+simd+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 CFLAGS := -g -Wall -Os -ffunction-sections -fdata-sections -flto -fuse-linker-plugin -fomit-frame-pointer -finline-small-functions \
 			$(ARCH) $(DEFINES)
 
-CFLAGS += $(INCLUDE) -D__SWITCH__ -DAPP_VERSION="\"$(APP_VERSION)\"" -D_FORTIFY_SOURCE=2
+CFLAGS += $(INCLUDE) -D__SWITCH__ -DAPPTITLE=\"$(APP_TITLE)\" -DAPP_VERSION="\"$(APP_VERSION)\"" -D_FORTIFY_SOURCE=2
 
 
 #---------------------------------------------------------------------------------

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -158,6 +158,9 @@ static std::atomic<bool> lastRunningInterpreter{false};
 
 
 
+
+
+
 template<typename Map, typename Func = std::function<std::string(const std::string&)>, typename... Args>
 std::string getValueOrDefault(const Map& data, const std::string& key, const std::string& defaultValue, Func formatFunc = nullptr, Args... args) {
     auto it = data.find(key);
@@ -5855,6 +5858,8 @@ public:
         std::set<std::string> overlaySet;
         bool drawHiddenTab = false;
         
+
+        
         // Scope to immediately free INI data after processing
         {
             auto overlaysIniData = getParsedDataFromIniFile(OVERLAYS_INI_FILEPATH);
@@ -5880,8 +5885,10 @@ public:
                 
                 auto it = overlaysIniData.find(overlayFileName);
                 if (it == overlaysIniData.end()) {
-                    const auto& [result, overlayName, overlayVersion, usingLibUltrahand] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
+                    auto [result, overlayName, overlayVersion, usingLibUltrahand] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                     if (result != ResultSuccess) continue;
+                    
+
     
                     auto& overlaySection = overlaysIniData[overlayFileName];
                     overlaySection[PRIORITY_STR] = "20";
@@ -5899,8 +5906,10 @@ public:
                     if (hide == TRUE_STR) drawHiddenTab = true;
                     
                     if ((!inHiddenMode && hide == FALSE_STR) || (inHiddenMode && hide == TRUE_STR)) {
-                        const auto& [result, overlayName, overlayVersion, usingLibUltrahand] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
+                        auto [result, overlayName, overlayVersion, usingLibUltrahand] = getOverlayInfo(OVERLAY_PATH + overlayFileName);
                         if (result != ResultSuccess) continue;
+                        
+
                         
                         const std::string priority = (it->second.find(PRIORITY_STR) != it->second.end()) ? formatPriorityString(it->second[PRIORITY_STR]) : "0020";
                         const std::string starred = getValueOrDefault(it->second, STAR_STR, FALSE_STR);


### PR DESCRIPTION
1. Hardware profile spoofing (for 8GB memory display issues)
This feature is intended for users whose devices were modified to 8GB but do not display correctly. It is optional and experimental and does not necessarily need to be merged into the main branch. Related code and components can be found in the .packages directory as references.

2. New command: set-ini-val-ifexist
This command helps prevent conflicts between components such as Sys Launch, Atmosphere, and Memory Conversion.
Functionality:
Checks whether a specified section exists in a given section of a file.
If the section exists, writes the specified key and value to it.
If the section does not exist, no operation is performed.
Usage:
set-ini-val-ifexist <file_path> <section_name> <key_name> <value_name>
Example:
set-ini-val-ifexist  /bootloader/hekate_ipl.ini emuMMc kernel atmosphere/mesosphere.bin

3. .packages folder
Contains components related to the hardware spoofing feature and other functionality mentioned above. These can be used as references if needed.