### PR TITLE
Add wildcard support to ini_file_source

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3383,7 +3383,7 @@ public:
                 listPath = "";
             }
             else if (sourceType == INI_FILE_STR) {
-                selectedItemsList = parseSectionsFromIni(iniPath);
+                selectedItemsList = parseSectionsFromIniSource(iniPath, maxItemsLimit);
                 iniPath.clear();
             }
             else if (sourceType == JSON_STR || sourceType == JSON_FILE_STR) {
@@ -3404,7 +3404,7 @@ public:
                 listPathOn = "";
             }
             else if (sourceTypeOn == INI_FILE_STR) {
-                selectedItemsListOn = parseSectionsFromIni(iniPathOn);
+                selectedItemsListOn = parseSectionsFromIniSource(iniPathOn, maxItemsLimit);
                 iniPathOn = "";
             }
             else if (sourceTypeOn == JSON_STR || sourceTypeOn == JSON_FILE_STR) {
@@ -3424,7 +3424,7 @@ public:
                 listPathOff = "";
             }
             else if (sourceTypeOff == INI_FILE_STR) {
-                selectedItemsListOff = parseSectionsFromIni(iniPathOff);
+                selectedItemsListOff = parseSectionsFromIniSource(iniPathOff, maxItemsLimit);
                 iniPathOff = "";
             }
             else if (sourceTypeOff == JSON_STR || sourceTypeOff == JSON_FILE_STR) {
@@ -5190,7 +5190,7 @@ bool drawCommandsMenu(
                             else if (cmd[0] == "ini_file_source") {
                                 std::string iniPath = cmd[1];
                                 preprocessPath(iniPath, packagePath);
-                                entryList = parseSectionsFromIni(iniPath);
+                                entryList = parseSectionsFromIniSource(iniPath);
                                 break;
                             }
                         }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -2052,7 +2052,34 @@ inline void applyPlaceholderReplacement(std::string& input, const std::string& p
     input.replace(pos, placeholder.length(), replacement);
 }
 
+/**
+ * @brief Returns INI section names for ini_file_source (single path or wildcard merge).
+ *
+ * Single-file paths use parseSectionsFromIni unchanged. Wildcard paths enumerate matching
+ * files and merge section names (skips empty and [config], deduplicates by first occurrence).
+ */
+inline std::vector<std::string> parseSectionsFromIniSource(const std::string& iniPathPattern, size_t maxItemsLimit = 0) {
+    if (iniPathPattern.find('*') == std::string::npos) {
+        return parseSectionsFromIni(iniPathPattern);
+    }
 
+    std::vector<std::string> merged;
+    const auto files = getFilesListByWildcards(iniPathPattern, maxItemsLimit);
+
+    for (const auto& filePath : files) {
+        for (const auto& sectionName : parseSectionsFromIni(filePath)) {
+            if (sectionName.empty() || sectionName == "config") {
+                continue;
+            }
+            if (std::find(merged.begin(), merged.end(), sectionName) != merged.end()) {
+                continue;
+            }
+            merged.push_back(sectionName);
+        }
+    }
+
+    return merged;
+}
 
 
 void applyReplaceIniPlaceholder(std::string& arg, const std::string& commandName, const std::string& iniPath) {
@@ -2122,7 +2149,7 @@ void applyReplaceIniPlaceholder(std::string& arg, const std::string& commandName
                     
                     // Load section names only once when needed
                     if (!sectionsLoaded) {
-                        sectionNames = parseSectionsFromIni(iniPath);
+                        sectionNames = parseSectionsFromIniSource(iniPath);
                         sectionsLoaded = true;
                     }
                     


### PR DESCRIPTION

Adds wildcard support to `ini_file_source`, similar to `file_source`. Merges INI section names from all matching files for menus and `{ini_file_source(*)}`.

Example:

```ini
[*More Configs]
ini_file_source /bootloader/ini/*.ini
filter config
reboot ini '{ini_file_source(*)}'