### PR TITLE
Add field=value JSON array lookup

### DIFF
--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -2252,6 +2252,8 @@ void applyReplaceIniPlaceholder(std::string& arg, const std::string& commandName
  *
  * Optimized version with variables moved to usage scope to avoid repeated allocations.
  * Supports "null" key as a fallback default for failed lookups.
+ * Array path segments accept numeric indices or field=value matches (case-sensitive;
+ * first match wins), e.g. {json_file(0,assets,name=Switchfin.nro,browser_download_url)}.
  *
  * @param arg The input string containing the placeholder.
  * @param commandName The name of the JSON command (e.g., "json", "json_file").
@@ -2318,8 +2320,30 @@ std::string replaceJsonPlaceholder(const std::string& arg, const std::string& co
             if (cJSON_IsObject(value)) {
                 value = cJSON_GetObjectItemCaseSensitive(value, key.c_str()); // Navigate through object
             } else if (cJSON_IsArray(value)) {
-                index = std::stoul(key); // Convert key to index for arrays
-                value = cJSON_GetArrayItem(value, index);
+                // Array path: numeric index (e.g. 12) or field=value match (e.g. name=Switchfin.nro).
+                // Dots in match values are literal (not nested keys). First case-sensitive match wins.
+                const size_t eqPos = key.find('=');
+                if (eqPos != std::string::npos && eqPos > 0) {
+                    const std::string field(key, 0, eqPos);
+                    cJSON* found = nullptr;
+                    const int arraySize = cJSON_GetArraySize(value);
+                    for (int i = 0; i < arraySize; ++i) {
+                        cJSON* item = cJSON_GetArrayItem(value, i);
+                        if (!cJSON_IsObject(item)) {
+                            continue;
+                        }
+                        cJSON* fieldItem = cJSON_GetObjectItemCaseSensitive(item, field.c_str());
+                        if (cJSON_IsString(fieldItem) && fieldItem->valuestring &&
+                            key.compare(eqPos + 1, std::string::npos, fieldItem->valuestring) == 0) {
+                            found = item;
+                            break;
+                        }
+                    }
+                    value = found; // nullptr on no match → same fallback as a bad index
+                } else {
+                    index = std::stoul(key); // Convert key to index for arrays
+                    value = cJSON_GetArrayItem(value, index);
+                }
             } else {
                 validValue = false; // Set validValue to false if value is neither object nor array
             }

--- a/source/utils.hpp
+++ b/source/utils.hpp
@@ -2253,7 +2253,7 @@ void applyReplaceIniPlaceholder(std::string& arg, const std::string& commandName
  * Optimized version with variables moved to usage scope to avoid repeated allocations.
  * Supports "null" key as a fallback default for failed lookups.
  * Array path segments accept numeric indices or field=value matches (case-sensitive;
- * first match wins), e.g. {json_file(0,assets,name=Switchfin.nro,browser_download_url)}.
+ * first match wins), e.g. {json_file(0,assets,name=Test.nro,browser_download_url)}.
  *
  * @param arg The input string containing the placeholder.
  * @param commandName The name of the JSON command (e.g., "json", "json_file").
@@ -2320,7 +2320,7 @@ std::string replaceJsonPlaceholder(const std::string& arg, const std::string& co
             if (cJSON_IsObject(value)) {
                 value = cJSON_GetObjectItemCaseSensitive(value, key.c_str()); // Navigate through object
             } else if (cJSON_IsArray(value)) {
-                // Array path: numeric index (e.g. 12) or field=value match (e.g. name=Switchfin.nro).
+                // Array path: numeric index (e.g. 12) or field=value match (e.g. name=Test.nro).
                 // Dots in match values are literal (not nested keys). First case-sensitive match wins.
                 const size_t eqPos = key.find('=');
                 if (eqPos != std::string::npos && eqPos > 0) {


### PR DESCRIPTION
## Summary
- Extend `{json(...)}` / `{json_file(...)}` array path segments to support `field=value` matching (e.g. `name=Switchfin.nro`), so packages can select release assets by filename instead of fragile numeric indices.
- Keep existing numeric index behavior unchanged; first case-sensitive match wins; no match uses the same `null` / `"null"` fallback as a bad index.

## Example
Before (asset order-dependent):
```ini
[switchfin - 0.9.1]
try:
download https://api.github.com/repos/dragonflylee/switchfin/releases?per_page=1 /config/ultrahand/downloads/switchfin-api.json
json_file /config/ultrahand/downloads/switchfin-api.json
download {json_file(0,assets,12,browser_download_url)} /config/ultrahand/downloads/switchfin.nro
mv /config/ultrahand/downloads/switchfin.nro /switch/switchfin/
delete /config/ultrahand/downloads/switchfin-api.json
```

After (stable by filename):
```ini
[switchfin - 0.9.1]
try:
download https://api.github.com/repos/dragonflylee/switchfin/releases?per_page=1 /config/ultrahand/downloads/switchfin-api.json
json_file /config/ultrahand/downloads/switchfin-api.json
download {json_file(0,assets,name=Switchfin.nro,browser_download_url)} /config/ultrahand/downloads/switchfin.nro
mv /config/ultrahand/downloads/switchfin.nro /switch/switchfin/
delete /config/ultrahand/downloads/switchfin-api.json
```